### PR TITLE
Tweak ignored dependency version in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
       - dependency-name: "react-dom"
         versions: [ ">18" ]
       - dependency-name: "react-error-boundary"
-        versions: [ ">18" ]
+        versions: [ ">4" ]
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
We don't want versions later than 4 'cos React 19.