### PR TITLE
Extract common translations

### DIFF
--- a/src/i18n/getTranslationsForPage.ts
+++ b/src/i18n/getTranslationsForPage.ts
@@ -60,6 +60,8 @@ export default function getTranslationsForPage(
   };
 }
 
+const KEY_COMMON_TRANSLATIONS = "__common__";
+
 function getTranslations(
   i18n: i18n,
   {
@@ -88,5 +90,10 @@ function getTranslations(
     );
   }
 
-  return translations;
+  const common = resourceBundle[KEY_COMMON_TRANSLATIONS] ?? {};
+
+  return {
+    /* global commons first so that in the event of page-specific commons they'll override these */ common,
+    ...translations,
+  };
 }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -19,24 +19,14 @@
         "heading": "Check your email",
         "description": "Complete your log in using the magic link we just sent."
       },
-      "error": "There's been an error",
-      "common": {
-        "loading": {
-          "text": "Loading…"
-        }
-      }
+      "error": "There's been an error"
     },
     "login-callback": {
       "meta": {
         "title": "Login • VSAT",
         "description": "VSAT login"
       },
-      "message": "Setting up your writing space…",
-      "common": {
-        "loading": {
-          "text": "Loading…"
-        }
-      }
+      "message": "Setting up your writing space…"
     },
     "author": {
       "meta": {
@@ -63,13 +53,6 @@
             "1": "Darn, something went wrong.",
             "2": "Oops, something went wrong."
           }
-        }
-      },
-      "common": {
-        "yes": "Yes",
-        "no": "No",
-        "loading": {
-          "text": "Loading…"
         }
       }
     },
@@ -145,10 +128,6 @@
         "story": {
           "published": "Story published ✌️"
         }
-      },
-      "common": {
-        "yes": "Yes",
-        "no": "No"
       }
     },
     "error": {
@@ -169,6 +148,13 @@
         },
         "heading": "{{title}}"
       }
+    }
+  },
+  "__common__": {
+    "yes": "Yes",
+    "no": "No",
+    "loading": {
+      "text": "Loading…"
     }
   }
 }

--- a/src/i18n/locales/pt-BR/translation.json
+++ b/src/i18n/locales/pt-BR/translation.json
@@ -15,22 +15,12 @@
       "submit": {
         "label": "Iniciar sessão"
       },
-      "error": "Ocorreu um erro",
-      "common": {
-        "loading": {
-          "text": "Carregamento…"
-        }
-      }
+      "error": "Ocorreu um erro"
     },
     "login-callback": {
       "meta": {
         "title": "Iniciar sessão • VSAT",
         "description": "VSAT Iniciar sessão"
-      },
-      "common": {
-        "loading": {
-          "text": "Carregamento…"
-        }
       }
     },
     "author": {
@@ -51,11 +41,6 @@
         "create-story": {
           "label": "Nova história"
         }
-      },
-      "common": {
-        "loading": {
-          "text": "Loading…"
-        }
       }
     },
     "story": {
@@ -63,7 +48,100 @@
         "title": "História • VSAT",
         "description": "Sua história"
       },
-      "heading": "{{title}}"
+      "heading": "{{title}}",
+      "scene": {
+        "heading": "{{title}}",
+        "image": {
+          "alt-text": "Thumbnail",
+          "preview": "Preview",
+          "placeholder": "Placeholder"
+        },
+        "action": {
+          "delete-image": {
+            "label": "Delete"
+          },
+          "cancel-image": {
+            "label": "Cancel"
+          },
+          "upload-image": {
+            "label": "Upload"
+          },
+          "undo": {
+            "label": "Undo"
+          },
+          "redo": {
+            "label": "Redo"
+          },
+          "save": {
+            "label": "Save"
+          },
+          "delete-scene": {
+            "label": "Delete scene",
+            "confirm": {
+              "prompt": "Delete this scene?"
+            }
+          },
+          "publish-story": {
+            "label": "Publish story"
+          },
+          "create-scene": {
+            "label": "New scene"
+          }
+        }
+      },
+      "notify": {
+        "error": {
+          "code": {
+            "1": "Darn, something went wrong.",
+            "2": "Oops, something went wrong.",
+            "4": "We can't find that story.",
+            "5": "We can't find that scene.",
+            "7": "A heading must be added before adding a paragraph.",
+            "8": "A heading must be added before adding a link.",
+            "9": "We had some trouble with the fiction.",
+            "10": "Oops, we had an issue uploading that image.",
+            "11": "Oops, we had an issue uploading that audio.",
+            "12": "Oops, we had an issue saving the fiction.",
+            "13": "The story must have at least one scene.",
+            "14": "Every scene must have some fiction.",
+            "15": "Every scene must have an image."
+          }
+        },
+        "scene": {
+          "content": {
+            "saved": "Story saved ✌️"
+          }
+        },
+        "story": {
+          "published": "Story published ✌️"
+        }
+      }
+    },
+    "error": {
+      "heading": "Oops",
+      "image": {
+        "alt-text": "An unhappy face"
+      },
+      "content": {
+        "admission": "Something's gone wrong on our side, sorry about that.",
+        "remediation": "Try refreshing the page: the error might be a blip."
+      }
+    },
+    "site": {
+      "story": {
+        "meta": {
+          "title": "Story • VSAT",
+          "description": "Your story"
+        },
+        "heading": "{{title}}"
+      }
+    }
+  },
+  "__common__": {
+    "yes": "Sim",
+    "no": "Não",
+    "loading": {
+      "text": "Carregamento…"
     }
   }
 }

--- a/tests/unit/i18n/getTranslationsForPage.test.ts
+++ b/tests/unit/i18n/getTranslationsForPage.test.ts
@@ -54,8 +54,8 @@ describe("getTranslationsForPage", () => {
     });
 
     assert.deepStrictEqual(translations, {
-      af: { title: "Fiela se kind" },
-      en: { title: "Fiela's child" },
+      af: { title: "Fiela se kind", common: {} },
+      en: { title: "Fiela's child", common: {} },
     });
   });
 
@@ -107,8 +107,8 @@ describe("getTranslationsForPage", () => {
     });
 
     assert.deepStrictEqual(translations, {
-      af: { title: "Fiela se kind" },
-      en: { title: "Fiela's child" },
+      af: { title: "Fiela se kind", common: {} },
+      en: { title: "Fiela's child", common: {} },
     });
   });
 
@@ -159,7 +159,7 @@ describe("getTranslationsForPage", () => {
     });
 
     assert.deepStrictEqual(translations, {
-      en: { title: "Fiela's child" },
+      en: { title: "Fiela's child", common: {} },
     });
   });
 
@@ -192,6 +192,127 @@ describe("getTranslationsForPage", () => {
 
     assert.deepStrictEqual(translations, {
       /* empty */
+    });
+  });
+
+  test("given existing translations for 'en/translation/home'" +
+    " and existing 'common' translations" +
+    " when we get the 'en' translations for the page 'home' in the default namespace 'translation'" +
+    " then the translations includes only those for 'en' ('en' being the default fallback)" +
+    " and the global 'common' translations", () => {
+    const currentLocale = "en"; // ⬅️ this is the default namespace
+    const fallbackLocale = "en";
+    const namespaceName = "translation"; // ⬅️ this is the default namespace
+    const pageName = "home";
+
+    const i18n = i18next.createInstance(
+      {
+        lng: currentLocale,
+        fallbackLng: fallbackLocale,
+        supportedLngs: [currentLocale, fallbackLocale],
+        resources: {
+          af: {
+            [namespaceName]: {
+              page: {
+                [pageName]: {
+                  title: "Fiela se kind",
+                },
+              },
+            },
+          },
+          en: {
+            [namespaceName]: {
+              page: {
+                [pageName]: {
+                  title: "Fiela's child",
+                },
+              },
+              __common__: {
+                loading: "General loading blurb",
+              },
+            },
+          },
+        },
+      },
+      (err) => {
+        if (err) {
+          assert.fail(err);
+        }
+      },
+    );
+
+    const translations = getTranslationsForPage(i18n)({
+      page: pageName,
+      /* using the default locale and namespace */
+    });
+
+    assert.deepStrictEqual(translations, {
+      en: {
+        title: "Fiela's child",
+        common: { loading: "General loading blurb" },
+      },
+    });
+  });
+
+  test("given existing translations for 'en/translation/home'" +
+    " and existing 'common' translations" +
+    " when we get the 'en' translations for the page 'home' in the default namespace 'translation'" +
+    " then the translations includes only those for 'en' ('en' being the default fallback)" +
+    " and the page's 'common' translations override the global 'common' translations", () => {
+    const currentLocale = "en"; // ⬅️ this is the default namespace
+    const fallbackLocale = "en";
+    const namespaceName = "translation"; // ⬅️ this is the default namespace
+    const pageName = "home";
+
+    const i18n = i18next.createInstance(
+      {
+        lng: currentLocale,
+        fallbackLng: fallbackLocale,
+        supportedLngs: [currentLocale, fallbackLocale],
+        resources: {
+          af: {
+            [namespaceName]: {
+              page: {
+                [pageName]: {
+                  title: "Fiela se kind",
+                },
+              },
+            },
+          },
+          en: {
+            [namespaceName]: {
+              page: {
+                [pageName]: {
+                  title: "Fiela's child",
+                  common: {
+                    loading: "Page-specific loading blurb",
+                  },
+                },
+              },
+              __common__: {
+                loading: "General loading blurb",
+              },
+            },
+          },
+        },
+      },
+      (err) => {
+        if (err) {
+          assert.fail(err);
+        }
+      },
+    );
+
+    const translations = getTranslationsForPage(i18n)({
+      page: pageName,
+      /* using the default locale and namespace */
+    });
+
+    assert.deepStrictEqual(translations, {
+      en: {
+        title: "Fiela's child",
+        common: { loading: "Page-specific loading blurb" },
+      },
     });
   });
 });


### PR DESCRIPTION
So that we're not repeating the same "common" translations on each page.