### PR TITLE
Make vsat the default database

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=vsat
 
       # https://hub.docker.com/_/postgres/
 


### PR DESCRIPTION
When running locally we want `vsat` to be the default database.

Currently the default is not `vsat` and the (local) connection string assumes that. It worked fine (for me) because at some point I created the `vsat` DB manually and yeah... it doesn't work out of the box for anyone else.