### PR TITLE
Use published state for story image

### DIFF
--- a/docs/db/migrations.md
+++ b/docs/db/migrations.md
@@ -20,5 +20,9 @@ This file must adhere to the following naming convention:
 YYYYMMDDHHMM-someDescriptiveName.ts
 ```
 
+```shell
+touch ./src/database/migrate/migrations/$(date +%F%H-%M | tr -d '-' | tr -d ':')-RENAME.ts
+```
+
 See [the docs](https://kysely.dev/docs/migrations#migration-files) and the
 existing migrations for examples of what to write.

--- a/src/database/migrate/migrations/202502221346-story-image.ts
+++ b/src/database/migrate/migrations/202502221346-story-image.ts
@@ -1,0 +1,21 @@
+import type { Kysely } from "kysely";
+
+import type { Database } from "../../schema.js";
+
+const TABLE_STORY_PUBLISHED = "story_published";
+
+const COLUMN_IMAGE_URL = "imageUrl";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable(TABLE_STORY_PUBLISHED)
+    .addColumn(COLUMN_IMAGE_URL, "varchar", (col) => col.defaultTo(null))
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable(TABLE_STORY_PUBLISHED)
+    .dropColumn(COLUMN_IMAGE_URL)
+    .execute();
+}

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -114,6 +114,7 @@ export interface TableStoryPublished {
   title: string;
   content: JSONColumnType<NonEmptyArray<PublishedScene>>;
   createdAt: Date;
+  imageUrl: string | null;
 }
 
 export type StoryPublishedDto = Selectable<TableStoryPublished>;

--- a/src/domain/story/getPublishedStoryInDatabase.ts
+++ b/src/domain/story/getPublishedStoryInDatabase.ts
@@ -21,6 +21,7 @@ function getPublishedStoryInDatabase(
         "storyPublished.id as storyId",
         "storyPublished.title as storyTitle",
         "storyPublished.content as storyContent",
+        "storyPublished.imageUrl as storyImageUrl",
         "storyPublished.createdAt",
         "author.id as authorId",
         "author.name as authorName",
@@ -42,6 +43,7 @@ type PublishedStoryAndAuthorRow = {
   storyId: number;
   storyTitle: string;
   storyContent: Json;
+  storyImageUrl: string | null;
   createdAt: Date;
   authorId: number;
   authorName: string;
@@ -57,5 +59,6 @@ function mapPublishedStory(row: PublishedStoryAndAuthorRow): PublishedStory {
     },
     createdAt: row.createdAt,
     scenes: row.storyContent as NonEmptyArray<PublishedScene>,
+    imageUrl: row.storyImageUrl,
   };
 }

--- a/src/domain/story/getPublishedStorySummariesInDatabase.ts
+++ b/src/domain/story/getPublishedStorySummariesInDatabase.ts
@@ -13,45 +13,36 @@ export default function getPublishedStorySummariesInDatabase(
   return async (request) => {
     log.debug({ request }, "Getting published stories");
 
-    const resultSet = await db()
+    const rows = await db()
       .selectFrom("storyPublished")
       .innerJoin("authorToStory", "authorToStory.storyId", "storyPublished.id")
       .innerJoin("author", "authorToStory.authorId", "author.id")
-      .innerJoin("scene", "scene.storyId", "storyPublished.id")
-      .leftJoin("image", "scene.imageId", "image.id")
       .select([
         // storyPublished
         "storyPublished.id as storyId",
         "storyPublished.title as storyTitle",
         "storyPublished.createdAt as storyPublishedOn",
+        "storyPublished.imageUrl as storyImageUrl",
         // author
         "author.id as authorId",
         "author.name as authorName",
-        // image
-        "image.thumbnailUrl as imageThumbnailUrl",
       ])
       .orderBy("storyPublished.createdAt", "desc")
       .execute();
 
-    const publishedStorySummaries: PublishedStorySummary[] = resultSet.map(
-      (row) => ({
-        id: row.storyId,
-        title: row.storyTitle,
-        publishedOn: row.storyPublishedOn,
-        imageUrl: row.imageThumbnailUrl,
-        author: {
-          id: row.authorId,
-          name: row.authorName,
-        },
-      }),
-    );
+    const summaries: PublishedStorySummary[] = rows.map((row) => ({
+      id: row.storyId,
+      title: row.storyTitle,
+      publishedOn: row.storyPublishedOn,
+      imageUrl: row.storyImageUrl,
+      author: {
+        id: row.authorId,
+        name: row.authorName,
+      },
+    }));
 
-    log.debug(
-      { request },
-      "Got %d published stories",
-      publishedStorySummaries.length,
-    );
+    log.debug({ request }, "Got %d published stories", summaries.length);
 
-    return publishedStorySummaries;
+    return summaries;
   };
 }

--- a/src/domain/story/publish/publishStoryInDatabase.ts
+++ b/src/domain/story/publish/publishStoryInDatabase.ts
@@ -21,6 +21,7 @@ export default function publishStoryInDatabase(
         title: story.title,
         content,
         createdAt: story.createdAt,
+        imageUrl: story.imageUrl,
       })
       .onConflict((oc) =>
         oc.column("id").doUpdateSet({

--- a/src/domain/story/published/parseStory.ts
+++ b/src/domain/story/published/parseStory.ts
@@ -14,7 +14,7 @@ export type ParseStoryFailed = ErrorCoded & {
   reason: string;
 };
 
-export type ParsedStory = Omit<PublishedStory, "createdAt">;
+export type ParsedStory = Omit<PublishedStory, "createdAt" | "imageUrl">;
 
 export type ParseStorySuccess = {
   kind: "storyParsed";

--- a/src/domain/story/published/types.ts
+++ b/src/domain/story/published/types.ts
@@ -13,6 +13,7 @@ export type PublishedStory = Readonly<
     Omit<PersistentStory, "scenes" | "publishedOn"> & {
       createdAt: Date;
       scenes: NonEmptyArray<PublishedScene>;
+      imageUrl: string | null;
     }
   >
 >;


### PR DESCRIPTION
Currently when we publish a story we persist the state of the published story... cool. If the first scene in the story has an image -- it's optional -- then the URLs to that scene/story image are persisted.

When we're retrieving a published story summary we _don't_ interrogate that state to get the first scene's image (if any); instead, we're joining to the _current_ state of the story which may be using an entirely different image for that opening scene.

This is... not good. When a story is published, it's a snapshot of the story at the time of publication. The "cover" mustn't suddenly change underfoot.

The changes here ensure that the image is static.