### PR TITLE
Only display controls on first page of story

### DIFF
--- a/src/components/story/published/PublishedStory.tsx
+++ b/src/components/story/published/PublishedStory.tsx
@@ -5,6 +5,7 @@ import type { ResourceKey } from "i18next";
 import { type FC, useState } from "react";
 import { I18nextProvider } from "react-i18next";
 
+import { isFirstPageInStory } from "@domain/story/publish/support/isFirstPage.js";
 import openingPageFor from "@domain/story/publish/support/openingPage.js";
 import openingSceneFor from "@domain/story/publish/support/openingScene.js";
 import type {
@@ -79,19 +80,21 @@ const PublishedStoryView: FC<PublishedStoryViewProps> = ({ story }) => {
           <Fiction content={currentPage.content} followLink={followLink} />
         </group>
 
-        <group position={[4.5, -2.5, 1]}>
-          <Root
-            sizeX={1}
-            gapRow={3}
-            flexDirection="column"
-            positionType={"static"}
-            positionTop={0}
-            positionLeft={0}
-          >
-            <GoFullscreen />
-            <ExitStory onExit={onExitStory} />
-          </Root>
-        </group>
+        {isFirstPageInStory(currentPage, currentScene) && (
+          <group position={[4.5, -2.5, 1]}>
+            <Root
+              sizeX={1}
+              gapRow={3}
+              flexDirection="column"
+              positionType={"static"}
+              positionTop={0}
+              positionLeft={0}
+            >
+              <GoFullscreen />
+              <ExitStory onExit={onExitStory} />
+            </Root>
+          </group>
+        )}
       </Hud>
     </Canvas>
   );

--- a/src/domain/story/publish/support/isFirstPage.ts
+++ b/src/domain/story/publish/support/isFirstPage.ts
@@ -1,0 +1,19 @@
+import type { Page, PublishedScene } from "../types.js";
+import sortPages from "./sortPages.js";
+
+/**
+ * Is the supplied `page` the first page of the supplied `scene` _and_ is the
+ * supplied `scene` the first scene in the story?
+ *
+ * This function is about finding the first page in the story overall, not just
+ * the first page in a particular scene.
+ */
+export function isFirstPageInStory(page: Page, scene: PublishedScene): boolean {
+  if (!scene.isOpeningScene) {
+    return false;
+  }
+
+  const sortedPages = sortPages(scene.pages);
+
+  return sortedPages[0].number === page.number;
+}

--- a/src/domain/story/publish/support/openingPage.ts
+++ b/src/domain/story/publish/support/openingPage.ts
@@ -1,17 +1,6 @@
-import type { NonEmptyArray } from "../../../../util/nonEmptyArray.js";
-import type { PublishedScene, Page } from "../types.js";
+import type { Page, PublishedScene } from "../types.js";
+import sortPages from "./sortPages.js";
 
 export default function openingPageFor(scene: PublishedScene): Page {
-  // the explicit cast is fine 'cos' we know that there is at least one page
-  const allPages = Object.values(scene.pages) as NonEmptyArray<Page>;
-
-  const sortedPages = allPages.toSorted(
-    inAscendingOrderOfPageNumber,
-  ) as NonEmptyArray<Page>;
-
-  return sortedPages[0];
-}
-
-function inAscendingOrderOfPageNumber(a: Page, b: Page): number {
-  return a.number - b.number;
+  return sortPages(scene.pages)[0];
 }

--- a/src/domain/story/publish/support/sortPages.ts
+++ b/src/domain/story/publish/support/sortPages.ts
@@ -1,0 +1,15 @@
+import type { NonEmptyArray } from "../../../../util/nonEmptyArray.js";
+import type { Page, PublishedScene } from "../types.js";
+
+export default function sortPages(
+  pages: PublishedScene["pages"],
+): NonEmptyArray<Page> {
+  // the explicit cast is fine 'cos' we know there is at least one page
+  return Object.values(pages).toSorted(
+    inAscendingOrderOfPageNumber,
+  ) as NonEmptyArray<Page>;
+}
+
+function inAscendingOrderOfPageNumber(a: Page, b: Page): number {
+  return a.number - b.number;
+}

--- a/src/domain/story/publish/types.ts
+++ b/src/domain/story/publish/types.ts
@@ -68,8 +68,25 @@ export type LinkBlock = {
 export type Block = HeadingBlock | PlaintextBlock | LinkBlock;
 
 export type Page = Readonly<{
+  /**
+   * This page's anchor.
+   *
+   * Other content can link to this page by using this value.
+   */
   link: LinkTarget;
+
+  /**
+   * This page's number in the scene.
+   *
+   * * the first page has number `0`
+   * * the second page has number `1`
+   * * etc.
+   */
   number: number;
+
+  /**
+   * This page's fiction.
+   */
   content: NonEmptyArray<Block>;
 
   /**


### PR DESCRIPTION
> I think it's actually better if the 'fullscreen'/edit options are only available on the first page of the story, for now. My feeling is that once you're in, you're in, and the 'exit' button is a bit distracting.