### PR TITLE
Tweak cursor styling and behaviour

### DIFF
--- a/src/components/story/published/PublishedStory.astro
+++ b/src/components/story/published/PublishedStory.astro
@@ -24,9 +24,9 @@ const openingScene = openingSceneFor(story);
   <a-camera position="0 0 1">
     <a-entity
       position="0 0 -3"
-      geometry="primitive: ring; radiusInner: 0.1; radiusOuter: 0.15"
-      material="color: hotpink; shader: flat"
-      cursor="maxDistance: 30; fuse: true; fuseTimeout: 2000"
+      geometry="primitive: ring; radiusInner: 0.05; radiusOuter: 0.1"
+      material="color: gray; shader: flat"
+      cursor="maxDistance: 30"
     >
     </a-entity>
   </a-camera>


### PR DESCRIPTION
Closes #165
Closes #166
Closes #167

## Before

<img width="830" height="718" alt="before" src="https://github.com/user-attachments/assets/77ea3085-7ac4-4cbb-aa46-d66c46e81c33" />

## After

<img width="812" height="713" alt="after" src="https://github.com/user-attachments/assets/7da458a2-50f8-468b-ba89-865659c78c0b" />
