### PR TITLE
Restyle scene fiction in VR

### DIFF
--- a/src/components/story/published/PublishedStory.astro
+++ b/src/components/story/published/PublishedStory.astro
@@ -19,7 +19,8 @@ const openingScene = openingSceneFor(story);
 <a-scene story sound="autoplay: false; positional: false">
   <a-sky src={openingScene.image?.url}></a-sky>
 
-  <a-entity id="fiction" position="0 1 -6"></a-entity>
+  <a-entity id="fiction" position="0 1 -6" layout="type: line; plane: yz;"
+  ></a-entity>
 
   <a-camera position="0 0 1">
     <a-entity

--- a/src/components/story/published/aframe/PrepareStory.astro
+++ b/src/components/story/published/aframe/PrepareStory.astro
@@ -90,7 +90,7 @@ const { story } = Astro.props;
 
           const entity = document.createElement("a-text");
           entity.setAttribute("block-heading", `text: ${text}`);
-          entity.setAttribute("position", "0 3 0.25");
+          entity.setAttribute("layout", "type: box; plane: yz; margin: 0.25;");
 
           return entity;
         })();
@@ -103,7 +103,18 @@ const { story } = Astro.props;
 
           const entity = document.createElement("a-entity");
           entity.setAttribute("block-plaintext", `text: ${text}`);
-          entity.setAttribute("position", "0 0.65 0");
+          entity.setAttribute("layout", "type: box; plane: yz; margin: 0.25;");
+
+          /*
+           * We need to calculate the height dynamically, 'cos it might be long
+           * enough to wrap across multiple lines.
+           */
+          const numberOfLines = Math.max(Math.trunc(text.length / 50), 1);
+          const numberOfNewlines = text.matchAll(/\n/g).toArray().length;
+          const lineCount = numberOfLines + numberOfNewlines;
+          const height = lineCount == 1 ? 1.75 : (lineCount - 1) * 0.85;
+
+          entity.setAttribute("height", height);
 
           return entity;
         })();
@@ -111,13 +122,16 @@ const { story } = Astro.props;
         const links = (() => {
           const linkBlocks = current.page.content.filter(isLinkBlock);
 
-          const elements = linkBlocks.map((block, count) => {
+          const elements = linkBlocks.map((block) => {
             const entity = document.createElement("a-entity");
             entity.setAttribute(
               "block-link",
               `text: ${block.text}; link: ${block.link}`,
             );
-            entity.setAttribute("position", `0 ${-(count + 2)} 0.25`);
+            entity.setAttribute(
+              "layout",
+              "type: box; plane: yz; margin: 0.25;",
+            );
 
             return entity;
           });
@@ -125,9 +139,9 @@ const { story } = Astro.props;
           return elements;
         })();
 
-        fiction.appendChild(heading);
-        fiction.appendChild(content);
         links.forEach((link) => fiction.appendChild(link));
+        fiction.appendChild(content);
+        fiction.appendChild(heading);
       }
     },
   });
@@ -140,8 +154,7 @@ const { story } = Astro.props;
       const theText = document.createElement("a-troika-text");
       theText.setAttribute("value", this.data.text);
       theText.setAttribute("font-size", "0.25");
-      theText.setAttribute("anchor", "left");
-      theText.setAttribute("position", "-3 0 0.3");
+      theText.setAttribute("max-width", "6");
 
       const theBackground = document.createElement("a-box");
       theBackground.setAttribute("class", "clickable");
@@ -150,8 +163,8 @@ const { story } = Astro.props;
       theBackground.setAttribute("height", "1");
       theBackground.setAttribute("depth", "0.25");
 
-      this.el.appendChild(theText);
       this.el.appendChild(theBackground);
+      this.el.appendChild(theText);
     },
   });
 
@@ -163,25 +176,17 @@ const { story } = Astro.props;
       const theText = document.createElement("a-troika-text");
       theText.setAttribute("value", this.data.text);
       theText.setAttribute("color", "#2C3E50");
-      theText.setAttribute("anchor", "left");
-      theText.setAttribute("align", "left");
       theText.setAttribute("max-width", "5.5");
       theText.setAttribute("line-height", "2");
-      theText.setAttribute("position", "-2.85 0 0.3");
-
-      const numberOfLines = Math.max(Math.trunc(this.data.text.length / 50), 1);
-      const numberOfNewlines = this.data.text.matchAll(/\n/g).toArray().length;
-      const lineCount = numberOfLines + numberOfNewlines;
-      const height = lineCount == 1 ? 1.75 : (lineCount - 1) * 0.85;
 
       const theBackground = document.createElement("a-box");
       theBackground.setAttribute("color", "#FBEEE6");
-      theBackground.setAttribute("width", "6.5");
-      theBackground.setAttribute("height", height);
+      theBackground.setAttribute("width", "7");
       theBackground.setAttribute("depth", "0.25");
+      theBackground.setAttribute("opacity", "0.75");
 
-      this.el.appendChild(theText);
       this.el.appendChild(theBackground);
+      this.el.appendChild(theText);
     },
   });
 
@@ -195,22 +200,25 @@ const { story } = Astro.props;
       theText.setAttribute("value", this.data.text);
       theText.setAttribute("data-raycastable", "");
       theText.setAttribute("color", "#ecf0f1");
-      theText.setAttribute("position", "-2 0 0.3");
+
+      const colorButtonNeutral = "#2C3E50";
 
       const theButton = document.createElement("a-box");
-      theButton.setAttribute("color", "#2980b9");
       theButton.setAttribute("width", "7");
-      theButton.setAttribute("height", "0.9");
       theButton.setAttribute("depth", "0.25");
-      theButton.setAttribute("event-set__mouseenter", "color: #2E8ECE");
-      theButton.setAttribute("event-set__mouseleave", "color: #2980b9");
+      theButton.setAttribute("color", colorButtonNeutral);
+      theButton.setAttribute("event-set__mouseenter", "color: #3C5976");
+      theButton.setAttribute(
+        "event-set__mouseleave",
+        `color: ${colorButtonNeutral}`,
+      );
 
-      this.el.appendChild(theText);
       this.el.appendChild(theButton);
+      this.el.appendChild(theText);
     },
     events: {
       click: function () {
-        this.el.emit("linkactivated", this.data.link);
+        this.el.emit(EVENT_LINK_ACTIVATED, this.data.link);
       },
     },
   });

--- a/src/pages/story/[storyId]/index.astro
+++ b/src/pages/story/[storyId]/index.astro
@@ -47,6 +47,10 @@ if (!story) {
       src="https://unpkg.com/aframe-troika-text/dist/aframe-troika-text.min.js"
       is:inline
       crossorigin="anonymous"></script>
+    <script
+      src="https://unpkg.com/aframe-layout-component@5.3.0/dist/aframe-layout-component.min.js"
+      is:inline
+      crossorigin="anonymous"></script>
   </head>
 </html>
 <body>


### PR DESCRIPTION
* the sections -- heading, text, links -- are now a cohesive billboard (as opposed to individually free-floating blocks)
* it's not shown in this screenshot but the text now wraps if it "over-runs" the area it's in

## Details

This uses the [aframe-layout-component](https://www.npmjs.com/package/aframe-layout-component) to manage the various blocks of the scene fiction; it's "yet another dependency" but it cleans up a bunch of the logic around laying out the blocks.

<img width="1618" height="868" alt="00" src="https://github.com/user-attachments/assets/368ea253-7178-42af-9844-2507eda9248c" />

