### PR TITLE
Fix preview rendering

### DIFF
--- a/src/pages/author/story/[storyId]/preview.astro
+++ b/src/pages/author/story/[storyId]/preview.astro
@@ -63,6 +63,10 @@ const publishedStory = {
       src="https://unpkg.com/aframe-troika-text/dist/aframe-troika-text.min.js"
       is:inline
       crossorigin="anonymous"></script>
+    <script
+      src="https://unpkg.com/aframe-layout-component@5.3.0/dist/aframe-layout-component.min.js"
+      is:inline
+      crossorigin="anonymous"></script>
   </head>
 </html>
 <body>


### PR DESCRIPTION
One of the new A-Frame scripts wasn't added to the preview which b0rk3d it.

Adding the script fixes it.