### PR TITLE
Harden persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -297,6 +297,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1862,6 +1863,7 @@
       "resolved": "https://registry.npmjs.org/@magic-sdk/provider/-/provider-30.0.0.tgz",
       "integrity": "sha512-zzIXbzTX/b5iRq43c8vVQDY/GUO891uqEgzXuDVbgs+20yRsUCJFJjvDcU9QC16kQ0tJTMAKHYObWayd5mAYbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@magic-sdk/types": "^25.0.0",
         "eventemitter3": "^4.0.4"
@@ -1880,7 +1882,8 @@
       "version": "25.0.0",
       "resolved": "https://registry.npmjs.org/@magic-sdk/types/-/types-25.0.0.tgz",
       "integrity": "sha512-KTIO98+R2CvJfY9LDD549Cx1EswzNRpTSTL5G4KjP71wOI0dVfq/dTRV+kWzUohzBBH5w5v0gmEy6YB82WRl/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@noble/curves": {
       "version": "1.2.0",
@@ -2851,6 +2854,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
       "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2861,6 +2865,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
       "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3492,6 +3497,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.13.7.tgz",
       "integrity": "sha512-Of2tST7ErbE4y1dVb4aWDXaQSIRBAfraJ4jDqaA3PzPRJOn6Ina36+tQ+8BezjYqiWwRRJdOEE07PRAJXnsddw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.7.2",
@@ -4146,6 +4152,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.2",
         "caniuse-lite": "^1.0.30001741",
@@ -5353,9 +5360,9 @@
       "license": "ISC"
     },
     "node_modules/dockerode/node_modules/tar-fs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
-      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6140,15 +6147,6 @@
       },
       "engines": {
         "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/fast-uri": {
@@ -6982,6 +6980,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -7471,6 +7470,7 @@
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
       "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "lie": "3.1.1"
       }
@@ -9580,6 +9580,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9683,13 +9684,12 @@
       }
     },
     "node_modules/pino": {
-      "version": "9.9.5",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
-      "integrity": "sha512-d1s98p8/4TfYhsJ09r/Azt30aYELRi6NNnZtEbqFw6BoGsdPVf5lKNK3kUwH8BmJJfpTLNuicjUQjaMbd93dVg==",
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.13.1.tgz",
+      "integrity": "sha512-Szuj+ViDTjKPQYiKumGmEn3frdl+ZPSdosHyt9SnUevFosOkMY2b7ipxlEctNKPmMD/VibeBI+ZcZCJK+4DPuw==",
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.1.1",
         "on-exit-leak-free": "^2.1.0",
         "pino-abstract-transport": "^2.0.0",
         "pino-std-serializers": "^7.0.0",
@@ -9697,6 +9697,7 @@
         "quick-format-unescaped": "^4.0.3",
         "real-require": "^0.2.0",
         "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
         "sonic-boom": "^4.0.1",
         "thread-stream": "^3.0.0"
       },
@@ -10082,6 +10083,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10094,6 +10096,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10542,6 +10545,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.1.tgz",
       "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11026,6 +11030,7 @@
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.114.0.tgz",
       "integrity": "sha512-r3KHl22433DlN5BpLAlL4b3D8ItoGKAkj91YT6GhP39XuLoBT+YFd9ObKuL/okgiPb5lbwnW+71fM45hHceN9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "immer": "^10.0.3",
         "is-plain-object": "^5.0.0",
@@ -11083,6 +11088,12 @@
         "slate": ">=0.114.0",
         "slate-dom": ">=0.110.2"
       }
+    },
+    "node_modules/slow-redact": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/slow-redact/-/slow-redact-0.3.1.tgz",
+      "integrity": "sha512-NvFvl1GuLZNW4U046Tfi8b26zXo8aBzgCAS2f7yVJR/fArN93mOqSA99cB9uITm92ajSz01bsu1K7SCVVjIMpQ==",
+      "license": "MIT"
     },
     "node_modules/smol-toml": {
       "version": "1.4.2",
@@ -11415,9 +11426,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
+      "integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11659,6 +11670,7 @@
       "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -11741,6 +11753,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12126,6 +12139,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
       "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -13005,6 +13019,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -187,9 +187,14 @@ export type CreateSceneInDatabase = (
   request: CreateSceneInDatabaseRequest,
 ) => Promise<SceneDto>;
 
+type SaveSceneContentInDatabaseRequest = {
+  storyId: StoryDto["id"];
+  sceneId: SceneDto["id"];
+  content: SceneDto["content"];
+};
+
 export type SaveSceneContentInDatabase = (
-  sceneId: SceneDto["id"],
-  content: SceneDto["content"],
+  request: SaveSceneContentInDatabaseRequest,
 ) => Promise<unknown>;
 
 // #endregion Scene

--- a/src/domain/audio/saveSceneAudio.ts
+++ b/src/domain/audio/saveSceneAudio.ts
@@ -36,7 +36,8 @@ export default function saveSceneAudio(
         audioId: audio.id,
       })
       .where("scene.id", "=", request.sceneId)
-      .execute();
+      .where("scene.storyId", "=", request.storyId)
+      .executeTakeFirstOrThrow();
 
     log.debug(
       { storyId: request.storyId, sceneId: request.sceneId, name, audio },

--- a/src/domain/image/saveSceneImage.ts
+++ b/src/domain/image/saveSceneImage.ts
@@ -40,7 +40,8 @@ export default function saveSceneImage(
         imageId: image.id,
       })
       .where("scene.id", "=", request.sceneId)
-      .execute();
+      .where("scene.storyId", "=", request.storyId)
+      .executeTakeFirstOrThrow();
 
     log.debug(
       { storyId: request.storyId, sceneId: request.sceneId, name, image },

--- a/src/domain/story/deleteSceneAudio.ts
+++ b/src/domain/story/deleteSceneAudio.ts
@@ -24,7 +24,7 @@ export default function deleteSceneAudio(
        * "delete this scene (audio)" so that's why we swallow it.
        */
 
-      log.warn({ err, request }, "Failed to delete scene image; swallowing");
+      log.warn({ err, request }, "Failed to delete scene audio; swallowing");
     }
   };
 }

--- a/src/domain/story/deleteSceneAudioInDatabase.ts
+++ b/src/domain/story/deleteSceneAudioInDatabase.ts
@@ -10,19 +10,20 @@ function deleteSceneAudioInDatabase(
 ): DeleteSceneAudio {
   const deleteAudio = deleteAudioInDatabase(log, db);
 
-  return async ({ sceneId, audioId }) => {
-    log.debug({ sceneId, audioId }, "Deleting scene's audio from DB");
+  return async ({ storyId, sceneId, audioId }) => {
+    log.debug({ storyId, sceneId, audioId }, "Deleting scene's audio from DB");
 
     // the scene may already be deleted: we don't care and plough on
     await db()
       .updateTable("scene")
       .set({ audioId: null })
       .where("scene.id", "=", sceneId)
+      .where("scene.storyId", "=", storyId)
       .execute();
 
     await deleteAudio(audioId);
 
-    log.debug({ sceneId, audioId }, "Deleted scene's audio from DB");
+    log.debug({ storyId, sceneId, audioId }, "Deleted scene's audio from DB");
   };
 }
 

--- a/src/domain/story/deleteSceneImageInDatabase.ts
+++ b/src/domain/story/deleteSceneImageInDatabase.ts
@@ -10,18 +10,19 @@ export default function deleteSceneImageInDatabase(
 ): DeleteSceneImage {
   const deleteImage = deleteImageInDatabase(log, db);
 
-  return async ({ sceneId, imageId }) => {
-    log.debug({ sceneId, imageId }, "Deleting scene's image from DB");
+  return async ({ storyId, sceneId, imageId }) => {
+    log.debug({ storyId, sceneId, imageId }, "Deleting scene's image from DB");
 
     // the scene may already be deleted: we don't care and plough on
     await db()
       .updateTable("scene")
       .set({ imageId: null })
       .where("scene.id", "=", sceneId)
+      .where("scene.storyId", "=", storyId)
       .execute();
 
     await deleteImage(imageId);
 
-    log.debug({ sceneId, imageId }, "Deleted scene's image from DB");
+    log.debug({ storyId, sceneId, imageId }, "Deleted scene's image from DB");
   };
 }

--- a/src/domain/story/deleteSceneInDatabase.ts
+++ b/src/domain/story/deleteSceneInDatabase.ts
@@ -15,6 +15,7 @@ function deleteSceneInDatabase(
     return db()
       .deleteFrom("scene")
       .where("scene.id", "=", sceneId)
+      .where("scene.storyId", "=", storyId)
       .returning(["imageId", "audioId"])
       .executeTakeFirstOrThrow();
   };

--- a/src/domain/story/route/routeSaveSceneContent.ts
+++ b/src/domain/story/route/routeSaveSceneContent.ts
@@ -24,6 +24,7 @@ function routeSaveSceneContent(
       }
 
       const parseResult = SaveSceneContentRequestModel.safeParse({
+        storyId: req.params.storyId,
         sceneId: req.params.sceneId,
         content: req.body,
       });
@@ -35,9 +36,9 @@ function routeSaveSceneContent(
         return;
       }
 
-      const { sceneId, content } = parseResult.data;
+      const { storyId, sceneId, content } = parseResult.data;
 
-      saveSceneContent(sceneId, content)
+      saveSceneContent({ storyId, sceneId, content })
         .then(() => {
           res.status(204).send();
         })
@@ -57,6 +58,7 @@ function routeSaveSceneContent(
 export default routeSaveSceneContent;
 
 export const SaveSceneContentRequestModel = z.object({
+  storyId: z.coerce.number().min(0),
   sceneId: z.coerce.number().min(0),
   content: z.string().trim().min(1),
 });

--- a/src/domain/story/saveSceneContentInDatabase.ts
+++ b/src/domain/story/saveSceneContentInDatabase.ts
@@ -9,8 +9,8 @@ function saveSceneContentInDatabase(
   log: Logger,
   db: GetDatabase,
 ): SaveSceneContentInDatabase {
-  return async (sceneId, content) => {
-    log.debug({ sceneId }, "Saving scene content");
+  return async ({ storyId, sceneId, content }) => {
+    log.debug({ storyId, sceneId }, "Saving scene content");
 
     await db()
       .updateTable("scene")
@@ -18,9 +18,10 @@ function saveSceneContentInDatabase(
         content,
       })
       .where("scene.id", "=", sceneId)
+      .where("scene.storyId", "=", storyId)
       .executeTakeFirstOrThrow();
 
-    log.debug({ sceneId }, "Saved scene content");
+    log.debug({ storyId, sceneId }, "Saved scene content");
   };
 }
 

--- a/src/domain/story/saveSceneTitleInDatabase.ts
+++ b/src/domain/story/saveSceneTitleInDatabase.ts
@@ -20,6 +20,7 @@ function saveSceneTitleInDatabase(
         title,
       })
       .where("scene.id", "=", sceneId)
+      .where("scene.storyId", "=", storyId)
       .executeTakeFirstOrThrow();
 
     log.debug({ sceneId, title }, "Saved scene title");

--- a/src/domain/story/support/assertIsAuthorHandler.ts
+++ b/src/domain/story/support/assertIsAuthorHandler.ts
@@ -1,13 +1,16 @@
 import type { RequestHandler } from "express";
 import type { Logger } from "pino";
 
+import { ErrorCodes } from "../../error/errorCode.js";
+import { errorCodedContext } from "../../error/errorCodedContext.js";
+
 /**
  * Build Express middleware asserting that there is a current user (author).
  *
  * Plug this middleware into routes where a logged-in user is required.
  */
 export default function assertIsAuthorHandler(log: Logger): RequestHandler {
-  return (req, _res, next) => {
+  return (req, res, next) => {
     log.trace({ author: req.user, path: req.path }, "Asserting author");
 
     if (!req.user) {
@@ -16,11 +19,11 @@ export default function assertIsAuthorHandler(log: Logger): RequestHandler {
         "The assert author handler requires an authenticated user: no user found on the request",
       );
 
-      return next(
-        new Error(
-          "The assert author handler requires an authenticated user: no user found on the request",
-        ),
-      );
+      res
+        .status(401)
+        .json(errorCodedContext(ErrorCodes.Unauthorized));
+
+      return;
     }
 
     return next();


### PR DESCRIPTION
Here's the output from running Open AI over the code:

• Findings

  - (High) src/domain/story/deleteSceneInDatabase.ts:15, src/domain/story/saveSceneContentInDatabase.ts:15, src/domain/story/saveSceneTitleInDatabase.ts:17, src/domain/image/saveSceneImage.ts:37, src/domain/ audio/saveSceneAudio.ts:33, src/domain/story/deleteSceneImageInDatabase.ts:17, src/domain/story/ deleteSceneAudioInDatabase.ts:18 – every write path that takes both storyId and sceneId drops storyId from the SQL WHERE. Any authenticated author can supply a scene id from another author’s story and mutate or delete that record because the database only checks scene.id. In saveSceneTitleInDatabase it even updates the foreign scene and then throws when the subsequent read fails, leaving the other author’s data modified. This is a direct authorization bypass and data corruption vector.
  - (High) src/domain/story/saveStoryInDatabase.ts:33 – when persisting scenes you never pass an id, but the ON CONFLICT clause expects a conflicting id. Updates to existing scenes therefore insert duplicates instead of updating the intended rows; subsequent loads surface duplicate scenes and the originals are left untouched. Persisting stories with existing scenes will quickly produce inconsistent content.
  - (Medium) src/domain/story/saveStoryInDatabase.ts:60 – the follow-up query that hydrates publishedOn omits a WHERE storyPublished.id = storyDto.id. It returns whichever published record happens to come first, so the new story can inherit another story’s publish timestamp, and unpublished stories can appear published.
  - (Medium) src/domain/story/support/assertIsAuthorOfTheStoryHandler.ts:20 and src/domain/story/support/ assertIsAuthorHandler.ts:13 – authorization failures call next(new Error(...)). Without a custom error handler this becomes an unhandled 500 rather than a 401/403, leaking the message into the response and confusing clients. It also bypasses the structured error responses used elsewhere.