### PR TITLE
fix: Add migration to reset scene sequence

### DIFF
--- a/src/database/migrate/migrations/202510201437-scene-sequence-restart.ts
+++ b/src/database/migrate/migrations/202510201437-scene-sequence-restart.ts
@@ -1,0 +1,24 @@
+import { type Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  /*
+   * We're restarting serial ID sequence for scenes at a higher value because
+   * the DB at the time of writing has some scenes with IDs above 1109 (and
+   * including 1109)… and the current serial ID sequence for scenes is 1109.
+   *
+   * This means that when we attempt to insert a new scene — which would use
+   * the next sequence value of 1110 — the insert fails because there already
+   * exists a scene with the ID 1100.
+   *
+   * This migration restarts the serial ID sequence for scenes at a value
+   * greater than the ID of any existing scene.
+   *
+   * Unsure as to the root cause of how this has happened: it could happen again
+   * 'cos this fix doesn't address the (unknown) root cause.
+   */
+  await sql`ALTER SEQUENCE scene_id_seq RESTART 1200`.execute(db);
+}
+
+export async function down(_db: Kysely<unknown>): Promise<void> {
+  // nothing to do
+}


### PR DESCRIPTION
Users are unable to add new scenes to their stories.

This is because the DB at the time of writing has some scenes with IDs above `1109` (and including 1109)… and the current serial ID sequence for scenes is 1109.

This means that when we attempt to insert a new scene — which would use the next sequence value of 1110 — the insert fails because there already exists a scene with the ID 1100.

This shows up in the logs as:

```
{"level":50,"time":1760965231840,"err":{"type":"DatabaseError","message":"duplicate key value violates unique constraint \"scene_pkey\"","stack":"error: duplicate key value violates unique constraint \"scene_pkey\"\n    at /app/node_modules/pg/lib/client.js:545:17\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async PostgresConnection.executeQuery (file:///app/node_modules/kysely/dist/esm/dialect/postgres/postgres-driver.js:90:49)\n    at async connection.executeQuery (file:///app/node_modules/kysely/dist/esm/driver/runtime-driver.js:110:24)\n    at async file:///app/node_modules/kysely/dist/esm/query-executor/query-executor-base.js:35:28\n    at async #run (file:///app/node_modules/kysely/dist/esm/driver/single-connection-provider.js:24:16)\n    at async DefaultQueryExecutor.executeQuery (file:///app/node_modules/kysely/dist/esm/query-executor/query-executor-base.js:34:16)\n    at async InsertQueryBuilder.execute (file:///app/node_modules/kysely/dist/esm/query-builder/insert-query-builder.js:1106:24)\n    at async InsertQueryBuilder.executeTakeFirst (file:///app/node_modules/kysely/dist/esm/query-builder/insert-query-builder.js:1122:26)\n    at async InsertQueryBuilder.executeTakeFirstOrThrow (file:///app/node_modules/kysely/dist/esm/query-builder/insert-query-builder.js:1134:24)\n    at PostgresConnection.executeQuery (file:///app/node_modules/kysely/dist/esm/dialect/postgres/postgres-driver.js:102:41)\n    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)\n    at async connection.executeQuery (file:///app/node_modules/kysely/dist/esm/driver/runtime-driver.js:110:24)\n    at async file:///app/node_modules/kysely/dist/esm/query-executor/query-executor-base.js:35:28\n    at async #run (file:///app/node_modules/kysely/dist/esm/driver/single-connection-provider.js:24:16)\n    at async DefaultQueryExecutor.executeQuery (file:///app/node_modules/kysely/dist/esm/query-executor/query-executor-base.js:34:16)\n    at async InsertQueryBuilder.execute (file:///app/node_modules/kysely/dist/esm/query-builder/insert-query-builder.js:1106:24)\n    at async InsertQueryBuilder.executeTakeFirst (file:///app/node_modules/kysely/dist/esm/query-builder/insert-query-builder.js:1122:26)\n    at async InsertQueryBuilder.executeTakeFirstOrThrow (file:///app/node_modules/kysely/dist/esm/query-builder/insert-query-builder.js:1134:24)\n    at async file:///app/dist/build/domain/story/createSceneInDatabase.js:4:23","length":183,"name":"error","severity":"ERROR","code":"23505","detail":"Key (id)=(1109) already exists.","schema":"public","table":"scene","constraint":"scene_pkey","file":"nbtinsert.c","line":"671","routine":"_bt_check_unique"},"parseResult":{"success":true,"data":{"storyId":1067}},"msg":"Error creating scene"}
```

This migration restarts the serial ID sequence for scenes at a value greater than the ID of any existing scene.

Unsure as to the root cause of how this has happened: it could happen again 'cos this fix doesn't address the (unknown) root cause.