### PR TITLE
Dev: add local-only auth bypass toggle

### DIFF
--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -22,6 +22,17 @@ MAGIC_PUBLISHABLE_KEY=
 NODE_V8_COVERAGE=./coverage
 ```
 
+Optional (development only):
+
+```
+DEV_AUTH_BYPASS=1
+DEV_AUTH_BYPASS_EMAIL=dev@localhost
+DEV_AUTH_BYPASS_NAME=Dev User
+```
+
+`DEV_AUTH_BYPASS` only applies when `NODE_ENV=development` and the request host
+is local (`localhost`, `127.0.0.1`, `::1`, or `*.localhost`).
+
 > You'll need to ask
 > [someone on the team](https://github.com/BrookesUniversityLearningResources/vsat/graphs/contributors)
 > for the values.

--- a/src/authentication/devAuthBypass.ts
+++ b/src/authentication/devAuthBypass.ts
@@ -1,0 +1,95 @@
+import type { RequestHandler } from "express";
+import type { Logger } from "pino";
+
+import type { RepositoryAuthor } from "../domain/index.js";
+import type { PersistentUser } from "./types.js";
+
+type DevAuthBypassOptions = {
+  enabled: boolean;
+  email: string;
+  name: string;
+};
+
+const isLocalDevHost = (host: string) =>
+  host === "localhost" ||
+  host === "127.0.0.1" ||
+  host === "::1" ||
+  host.endsWith(".localhost");
+
+export default function devAuthBypass(
+  log: Logger,
+  repositoryAuthor: RepositoryAuthor,
+  options: DevAuthBypassOptions,
+): RequestHandler {
+  if (!options.enabled) {
+    return (_req, _res, next) => next();
+  }
+
+  let cachedUser: PersistentUser | null = null;
+  let inflight: Promise<PersistentUser> | null = null;
+
+  const getOrCreateUser = async () => {
+    if (cachedUser) {
+      return cachedUser;
+    }
+
+    if (inflight) {
+      return inflight;
+    }
+
+    inflight = (async () => {
+      const existing = await repositoryAuthor.getAuthorByEmail(options.email);
+
+      if (existing) {
+        cachedUser = {
+          id: existing.id,
+          name: existing.name,
+          email: existing.email,
+        };
+        return cachedUser;
+      }
+
+      const created = await repositoryAuthor.createAuthor({
+        name: options.name,
+        email: options.email,
+      });
+
+      cachedUser = {
+        id: created.id,
+        name: created.name,
+        email: created.email,
+      };
+
+      return cachedUser;
+    })();
+
+    try {
+      return await inflight;
+    } finally {
+      inflight = null;
+    }
+  };
+
+  return (req, _res, next) => {
+    if (req.user) {
+      return next();
+    }
+
+    const host = req.hostname || req.host || "";
+    if (!isLocalDevHost(host)) {
+      log.warn({ host }, "Skipping dev auth bypass for non-local host");
+      return next();
+    }
+
+    getOrCreateUser()
+      .then((user) => {
+        req.user = user;
+        log.debug({ user, host }, "Dev auth bypass attached user to request");
+        next();
+      })
+      .catch((err) => {
+        log.warn({ err, host }, "Dev auth bypass failed to attach user");
+        next(err);
+      });
+  };
+}

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -3,6 +3,7 @@ import { type RequestHandler, Router } from "express";
 import type { Logger } from "pino";
 
 import authenticationRequired from "./authentication/authenticationRequired.js";
+import devAuthBypass from "./authentication/devAuthBypass.js";
 import passportWithMagicLogin from "./authentication/passport/passportWithMagicLogin.js";
 import routeAuthenticate from "./authentication/routeAuthenticate.js";
 import routeLogout from "./authentication/routeLogout.js";
@@ -56,9 +57,22 @@ export default async function createApp(): Promise<[StartServer, Logger]> {
     repositoryAuthor.createAuthor,
   );
 
+  const devAuthBypassEnabled =
+    process.env.NODE_ENV === "development" &&
+    (process.env.DEV_AUTH_BYPASS === "1" ||
+      process.env.DEV_AUTH_BYPASS === "true");
+  const devAuthBypassEmail =
+    process.env.DEV_AUTH_BYPASS_EMAIL ?? "dev@localhost";
+  const devAuthBypassName = process.env.DEV_AUTH_BYPASS_NAME ?? "Dev User";
+
   const middlewares: RequestHandler[] = [
     httpSession(config.server.session, connectionPool),
     passport.session(),
+    devAuthBypass(log, repositoryAuthor, {
+      enabled: devAuthBypassEnabled,
+      email: devAuthBypassEmail,
+      name: devAuthBypassName,
+    }),
     authenticationRequired(
       log,
       config.authentication.pathsRequiringAuthentication,

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -50,13 +50,6 @@ export default async function createApp(): Promise<[StartServer, Logger]> {
       App.WithSceneRepository
   >();
 
-  const passport = passportWithMagicLogin(
-    log,
-    await Magic.init(config.authentication.magic.secretKey),
-    repositoryAuthor.getAuthorByEmail,
-    repositoryAuthor.createAuthor,
-  );
-
   const devAuthBypassEnabled =
     process.env.NODE_ENV === "development" &&
     (process.env.DEV_AUTH_BYPASS === "1" ||
@@ -65,9 +58,35 @@ export default async function createApp(): Promise<[StartServer, Logger]> {
     process.env.DEV_AUTH_BYPASS_EMAIL ?? "dev@localhost";
   const devAuthBypassName = process.env.DEV_AUTH_BYPASS_NAME ?? "Dev User";
 
+  let passportSessionMiddleware: RequestHandler = (_req, _res, next) => next();
+  let authenticateHandler: RequestHandler = (_req, res) => {
+    res.status(503).json({ error: "Magic authentication is unavailable" });
+  };
+
+  try {
+    const passport = passportWithMagicLogin(
+      log,
+      await Magic.init(config.authentication.magic.secretKey),
+      repositoryAuthor.getAuthorByEmail,
+      repositoryAuthor.createAuthor,
+    );
+
+    passportSessionMiddleware = passport.session();
+    authenticateHandler = passport.authenticate("magic");
+  } catch (err) {
+    if (!devAuthBypassEnabled) {
+      throw err;
+    }
+
+    log.warn(
+      { err },
+      "Magic initialization failed; continuing with dev auth bypass only",
+    );
+  }
+
   const middlewares: RequestHandler[] = [
     httpSession(config.server.session, connectionPool),
-    passport.session(),
+    passportSessionMiddleware,
     devAuthBypass(log, repositoryAuthor, {
       enabled: devAuthBypassEnabled,
       email: devAuthBypassEmail,
@@ -159,7 +178,7 @@ export default async function createApp(): Promise<[StartServer, Logger]> {
 
   const routes = [
     routeHealthcheck(log),
-    routeAuthenticate(log, passport.authenticate("magic")),
+    routeAuthenticate(log, authenticateHandler),
     routeLogout(log),
     apiRoutes,
   ];


### PR DESCRIPTION
## Summary
This PR restores the local development auth convenience as an explicit, isolated toggle.

## What changed
- add a dev auth bypass middleware that can attach a local development user
- gate the bypass behind `DEV_AUTH_BYPASS`
- restrict it so it only activates when `NODE_ENV=development`
- restrict it so it only activates for local hosts (`localhost`, `127.0.0.1`, `::1`, `*.localhost`)
- document the toggle and its limits in the environment variable docs

## Why this is separate
Auth shortcuts deserve their own scrutiny. This keeps the convenience available for local authoring and e2e work without implying that it is part of the VSATLAS feature itself or a normal production auth path.

## Verification
- `npm run build`
