### PR TITLE
Fix i18n init options typing

### DIFF
--- a/src/i18n/createI18NContext.ts
+++ b/src/i18n/createI18NContext.ts
@@ -36,7 +36,6 @@ function initializeI18n(overrides: Partial<InitOptions> = {}) {
     backend: {
       loadPath: "src/i18n/locales/{{lng}}/{{ns}}.json",
     },
-    showSupportNotice: false,
     ...overrides,
   };
 


### PR DESCRIPTION
## Summary
Remove an unsupported `i18next` init option that currently breaks `npm run build` on fresh branches from upstream `main`.

## What changed
- remove `showSupportNotice` from the `InitOptions` object in `src/i18n/createI18NContext.ts`

## Why
The property is not part of `i18next`'s `InitOptions` type, so TypeScript rejects the build with:

`TS2353: Object literal may only specify known properties, and 'showSupportNotice' does not exist in type 'InitOptions<object>'`

## Verification
- `npm run build`
