### PR TITLE
Add shell option for Windows support

### DIFF
--- a/scripts/devHot.mjs
+++ b/scripts/devHot.mjs
@@ -25,6 +25,7 @@ const envFromFile = loadEnvFile();
 const run = (command, args, name) => {
   const child = spawn(command, args, {
     stdio: "inherit",
+    shell: true,
     env: {
       ...process.env,
       ...envFromFile,


### PR DESCRIPTION
The `hot` script doesn't work on Windows without the explicit `shell` option.

* [Docs](https://nodejs.org/api/child_process.html#child-processspawncommand-args-options)
## The error

```
$ npm run dev:hot

> vsat@0.0.1 dev:hot
> node ./scripts/devHot.mjs

node:events:485
      throw er; // Unhandled 'error' event
      ^

Error: spawn npm ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
Emitted 'error' event on ChildProcess instance at:
    at ChildProcess._handle.onexit (node:internal/child_process:292:12)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'spawn npm',
  path: 'npm',
  spawnargs: [ 'run', 'astro:dev' ]
}

Node.js v24.0.0
```