### PR TITLE
Fix path to Astro middleware

### DIFF
--- a/src/server/attachAstroMiddleware.ts
+++ b/src/server/attachAstroMiddleware.ts
@@ -1,7 +1,7 @@
 import express, { type Express } from "express";
 
-// @ts-expect-error Astro builds entry.mjs into dist/build/server/astro/ (see astro.config.mjs build.server)
-import { handler as astroHandler } from "./astro/entry.mjs";
+// @ts-expect-error Astro builds entry.mjs into dist/... (see astro.config.mjs build.server)
+import { handler as astroHandler } from "../../server/astro/entry.mjs";
 
 export default function attachAstroMiddleware(app: Express) {
   // https://docs.astro.build/en/guides/integrations-guide/node/


### PR DESCRIPTION
The recent change to the way we've setup dev mode means that the existing path to the built Astro middleware is b0rk3d.

This change fixes the path in light of those changes.