### PR TITLE
Lower maximum image upload size to match Cloudinary's

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -19,7 +19,7 @@
   },
   "uploads": {
     "image": {
-      "maxBytes": 25000000
+      "maxBytes": 10000000
     },
     "audio": {
       "maxBytes": 50000000

--- a/src/domain/story/route/routeUploadSceneImage.ts
+++ b/src/domain/story/route/routeUploadSceneImage.ts
@@ -76,6 +76,7 @@ function routeUploadSceneImage(
           return res.status(400).json(
             errorCodedContext(ErrorCodes.ErrorUploadingImageExceedsSizeLimit, {
               err,
+              limit: `${limit.maxBytes / 1_000_000}MB`,
             }),
           );
         }

--- a/src/i18n/locales/en/translation.json
+++ b/src/i18n/locales/en/translation.json
@@ -268,7 +268,7 @@
             "20": "Oops, we had an issue saving that name.",
             "21": "You must login to access that part of the site.",
             "27": "The audio file is too big to upload.",
-            "28": "The image file is too big to upload.",
+            "28": "The image file is too big to upload, please ensure it is less than {{limit}}",
             "29": "Link names must be unique."
           }
         },

--- a/src/i18n/locales/pt-BR/translation.json
+++ b/src/i18n/locales/pt-BR/translation.json
@@ -268,7 +268,7 @@
             "20": "Oops, we had an issue saving that name.",
             "21": "You must login to access that part of the site.",
             "27": "The audio file is too big to upload.",
-            "28": "The image file is too big to upload.",
+            "28": "The image file is too big to upload, please ensure it is less than {{limit}}",
             "29": "Link names must be unique."
           }
         },


### PR DESCRIPTION
We're on the [Free Plan in Cloudinary](https://cloudinary.com/pricing/compare-plans) so there's a 10MB image maximum image size. This change just configures our app to match that of the underlying system which is Cloudinary.

<img width="656" height="214" alt="Screenshot 2026-05-07 132455" src="https://github.com/user-attachments/assets/07a3febc-98c2-455e-99c7-0d1780a1eac6" />

## Error message

The error message that a user sees should, hopefully, be more actionable... the image is too big, make it smaller in size.

<img width="427" height="200" alt="Screenshot 2026-05-07 133219" src="https://github.com/user-attachments/assets/d6f1caec-ada2-4feb-a3d7-bca2a264b187" />
