### PR TITLE
Improve public story memory behavior

### DIFF
--- a/src/domain/story/getPublishedStorySummariesInDatabase.ts
+++ b/src/domain/story/getPublishedStorySummariesInDatabase.ts
@@ -29,7 +29,6 @@ export default function getPublishedStorySummariesInDatabase(
         "storyPublished.title as storyTitle",
         "storyPublished.createdAt as storyPublishedOn",
         "storyPublished.imageUrl as storyImageUrl",
-        "storyPublished.content as storyContent",
         "image.thumbnailUrl as openingSceneImageUrl",
         // author
         "author.id as authorId",
@@ -39,9 +38,7 @@ export default function getPublishedStorySummariesInDatabase(
       .execute();
 
     const summaries: PublishedStorySummary[] = rows.map((row) => {
-      const contentImageUrl = getImageFromPublishedContent(row.storyContent);
-      const imageUrl =
-        row.storyImageUrl ?? row.openingSceneImageUrl ?? contentImageUrl;
+      const imageUrl = row.storyImageUrl ?? row.openingSceneImageUrl;
 
       return {
         id: row.storyId,
@@ -59,40 +56,4 @@ export default function getPublishedStorySummariesInDatabase(
 
     return summaries;
   };
-}
-
-type PublishedSceneImage = {
-  url?: string | null;
-  thumbnailUrl?: string | null;
-};
-
-type PublishedSceneLike = {
-  isOpeningScene?: boolean;
-  image?: PublishedSceneImage | null;
-};
-
-function getImageFromPublishedContent(content: unknown) {
-  if (!content) {
-    return null;
-  }
-
-  try {
-    const scenes =
-      typeof content === "string" ? (JSON.parse(content) as unknown) : content;
-    if (!Array.isArray(scenes) || scenes.length === 0) {
-      return null;
-    }
-
-    const opening =
-      (scenes.find(
-        (scene): scene is PublishedSceneLike =>
-          typeof scene === "object" && scene !== null && "isOpeningScene" in scene,
-      ) as PublishedSceneLike | undefined) ??
-      (scenes[0] as PublishedSceneLike | undefined);
-
-    const image = opening?.image;
-    return image?.thumbnailUrl ?? image?.url ?? null;
-  } catch {
-    return null;
-  }
 }

--- a/src/pages/story/vsatlatarium.astro
+++ b/src/pages/story/vsatlatarium.astro
@@ -1,8 +1,11 @@
 ---
 import ImportAFrameScripts from "@components/story/published/aframe/ImportAFrameScripts.astro";
-import Layout from "../../layouts/PublicSiteLayout.astro";
-import type { PublishedStory, PublishedScene } from "@domain/story/publish/types";
+import type {
+  PublishedScene,
+  PublishedStory,
+} from "@domain/story/publish/types";
 import { cached } from "@util/layoutCache";
+import Layout from "../../layouts/PublicSiteLayout.astro";
 
 export const prerender = false;
 
@@ -13,6 +16,8 @@ const { log, repositoryStory, repositoryStoryLink, repositoryPilot } =
 
 const pilotParam = Astro.url.searchParams.get("pilot");
 const pilotId = pilotParam ? Number(pilotParam) : null;
+const MAX_VSATLATARIUM_STORIES = 60;
+const FULL_STORY_FETCH_CONCURRENCY = 3;
 
 let summaries: Awaited<ReturnType<typeof repositoryStory.getPublishedStorySummaries>> =
   [];
@@ -21,6 +26,8 @@ let interStoryLinks: Awaited<ReturnType<typeof repositoryStoryLink.getAllStoryLi
 let fullStories: PublishedStory[] = [];
 let pilots: Awaited<ReturnType<typeof repositoryPilot.getPilots>> = [];
 let storyDataUnavailable = false;
+let storyLimitExceeded = false;
+let requiresPilotSelection = false;
 
 try {
   const pilotStoriesPromise = pilotId
@@ -36,11 +43,19 @@ try {
 
   pilots = allPilots;
 
-  // Filter to pilot's stories if a pilot is selected
+  // VSATLATARIUM is intentionally bounded: prefer anthology-scoped story sets
+  // and cap the full-story payload because each published story carries scene
+  // content and media references.
   const pilotStoryIds = pilotId ? new Set(pilotStories.map((s) => s.id)) : null;
-  summaries = pilotStoryIds
+  const scopedSummaries = pilotStoryIds
     ? allSummaries.filter((s) => pilotStoryIds.has(s.id))
-    : allSummaries;
+    : pilots.length > 0
+      ? []
+      : allSummaries;
+  requiresPilotSelection = !pilotId && pilots.length > 0;
+  storyLimitExceeded = scopedSummaries.length > MAX_VSATLATARIUM_STORIES;
+  summaries = scopedSummaries.slice(0, MAX_VSATLATARIUM_STORIES);
+
   const visibleStoryIds = new Set(summaries.map((s) => s.id));
   interStoryLinks = allLinks.filter(
     (l) => visibleStoryIds.has(l.fromStory.id) && visibleStoryIds.has(l.toStory.id),
@@ -48,8 +63,10 @@ try {
 
   // Fetch full story data to get scenes and internal navigation links
   fullStories = (
-    await Promise.all(
-      summaries.map((s) => repositoryStory.getPublishedStory(s.id)),
+    await mapConcurrent(
+      summaries,
+      FULL_STORY_FETCH_CONCURRENCY,
+      (s) => repositoryStory.getPublishedStory(s.id),
     )
   ).filter((s): s is PublishedStory => s !== null);
 } catch (err) {
@@ -103,6 +120,29 @@ const normalizeLabelText = (value: string) =>
     .replace(/[\u2010-\u2015\u2212:;_-]+/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+
+async function mapConcurrent<T, U>(
+  values: ReadonlyArray<T>,
+  concurrency: number,
+  mapper: (value: T) => Promise<U>,
+): Promise<U[]> {
+  const results = new Array<U>(values.length);
+  let nextIndex = 0;
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    async () => {
+      while (nextIndex < values.length) {
+        const index = nextIndex;
+        nextIndex += 1;
+        results[index] = await mapper(values[index] as T);
+      }
+    },
+  );
+
+  await Promise.all(workers);
+  return results;
+}
 
 // --- Build cluster data ---
 type Vec3 = { x: number; y: number; z: number };
@@ -605,6 +645,18 @@ const clientData = {
       </aside>
     )}
 
+    {requiresPilotSelection && (
+      <aside class="vsatlatarium__notice" role="status">
+        Choose an anthology to load VSATLATARIUM.
+      </aside>
+    )}
+
+    {storyLimitExceeded && (
+      <aside class="vsatlatarium__notice" role="status">
+        Showing the first {MAX_VSATLATARIUM_STORIES} stories in this anthology.
+      </aside>
+    )}
+
     <div class="vsatlatarium__content">
       <div class="vsatlatarium__canvas">
         <div class="vsatlatarium__toolbar">
@@ -807,10 +859,12 @@ const clientData = {
           <div class="vsatlatarium__pilots">
             <h3>Anthology</h3>
             <div class="pilot-chips">
-              <a
-                class={`pilot-chip ${!pilotId ? "pilot-chip--active" : ""}`}
-                href={`/story/vsatlatarium${isPlanetarium ? "" : "?view=geomview"}`}
-              >All stories</a>
+              {pilots.length === 0 && (
+                <a
+                  class={`pilot-chip ${!pilotId ? "pilot-chip--active" : ""}`}
+                  href={`/story/vsatlatarium${isPlanetarium ? "" : "?view=geomview"}`}
+                >All stories</a>
+              )}
               {pilots.map((pilot) => (
                 <a
                   class={`pilot-chip ${pilot.id === pilotId ? "pilot-chip--active" : ""}`}


### PR DESCRIPTION
## Summary

This PR reduces memory pressure on public story views, especially VSATLATARIUM:

- stop selecting and parsing `storyPublished.content` in published-story summary queries
- rely on the publish-time `storyPublished.imageUrl` value, with the current opening-scene thumbnail join as fallback
- make VSATLATARIUM anthology-scoped when anthologies exist
- cap VSATLATARIUM full-story loading at 60 stories
- replace the full-story `Promise.all` burst with a bounded worker pool

Holding this open for review/comment rather than immediate merge.

## Validation

Local checks:

- `npm run build`
- `npm run test:unit` — 23 tests passing
- `npx @biomejs/biome lint src/domain/story/getPublishedStorySummariesInDatabase.ts src/pages/story/vsatlatarium.astro`
- `git diff --check`

Deployed current branch to Heroku `vsat-dev` as release `v20` and pressure-tested against `https://vsat-dev-a59e8b7d8397.herokuapp.com/`.

Pressure test:

- 20 concurrent authoring sessions using a ~9.1 MB panorama derivative
- each session created a story, uploaded the image, published it, and assigned it to a test anthology
- result: 20/20 succeeded, 0 failures
- upload latency: p50 6.9s, p95 10.9s, max 11.6s
- end-to-end session latency: p50 9.7s, p95 11.3s, max 11.8s

Public page burst after authoring load:

- `/story/`, 20 concurrent: p95 221ms
- `/story/vsatlatarium`, 20 concurrent: p95 102ms and confirmed anthology prompt
- `/story/vsatlatarium?pilot=1`, 10 concurrent: p95 205ms

Heroku memory samples during the run:

- post-deploy baseline: about 134 MB total
- peak during concurrent uploads: 485.12 MB / 512 MB, with about 49 MB swap
- settled afterward around 380 MB total, swap still around 49 MB
- no sampled R14/R15, upload errors, or 5xx lines in filtered Heroku logs

## Notes

This improves public-page memory behavior. It does not solve the separate upload-path issue where many concurrent near-limit images can still push a Basic dyno close to the 512 MB quota.
