### PR TITLE
Add returnTo auth flow, interpretive-link voting, and role docs

### DIFF
--- a/docs/qa-checklist.md
+++ b/docs/qa-checklist.md
@@ -90,6 +90,8 @@ Test each item and mark with ✅ or ❌.
 
 ## Author Links (`/author/links`)
 
+- [ ] Non-steward view only shows links touching stories authored by the current user
+- [ ] Steward view shows all links site-wide
 - [ ] Link cards show type, status, from→to stories, rationale
 - [ ] Cards color-coded by status (blue=accepted, yellow=proposed, pink=rejected)
 - [ ] Accept/Reject buttons work and update card status
@@ -108,6 +110,12 @@ Test each item and mark with ✅ or ❌.
 - [ ] Rows have hover highlight and alternating backgrounds
 - [ ] Retire/Unretire button works
 
+## Public Story Stewardship History (`/story/{id}`)
+
+- [ ] Retired links touching the story appear in the interpretive drawer
+- [ ] Retired links show type, peer story, and rationale
+- [ ] No retire/unretire controls appear on the public story page
+
 ## Stewardship Compact (`/stewardship`)
 
 - [ ] Sections have blue left-border accents
@@ -118,4 +126,6 @@ Test each item and mark with ✅ or ❌.
 
 - [ ] Existing links displayed with status coloring
 - [ ] Propose link form has styled container and pill submit
-- [ ] Vote buttons work
+- [ ] Vote buttons appear for authors of linked stories and stewards
+- [ ] Vote buttons are hidden for logged-in non-authors
+- [ ] Vote API returns 403 for logged-in non-authors

--- a/docs/role-sitemap.md
+++ b/docs/role-sitemap.md
@@ -6,7 +6,7 @@ Purpose: audit that every intended interaction is reachable for the role it is m
 - **author** — logged in; can edit stories they authored
 - **steward** — authenticated user whose email is listed in `STEWARD_EMAILS` (or who has flipped the `vsat_steward` dev cookie when `DEV_STEWARD_TOGGLE=1`)
 
-"Author" is not a separate account type — any logged-in user has author powers on stories they own. Ownership is checked per-story by `assertAuthorMiddleware` on `/author/story/:storyId/...` (except the `/links` sub-route, which is open to any logged-in user so anyone can vote on links that touch a story). Stewards bypass the ownership check.
+"Author" is not a separate account type — any logged-in user has author powers on stories they own. Ownership is checked per-story by `assertAuthorMiddleware` on `/author/story/:storyId/...` (except the `/links` sub-route, which is open to logged-in link work). Stewards do not bypass content ownership checks; their additional powers are link stewardship actions.
 
 ## Access gates at a glance
 
@@ -34,14 +34,17 @@ Unauthenticated hits to guarded paths redirect to `/login`. A logged-in non-owne
 - all roles: browse published stories, link to VSATLATARIUM.
 
 ### `/story/:storyId` — read a story
-- all roles: same view. A-Frame scene viewer; "Interpretive" sidebar (press `I`) showing **accepted** links only; endcap cards to adjacent stories. No role branching in the page itself.
-- Note: the empty-state text says "Try VSATLATARIUM to propose one," but the propose UI is **not** exposed here or in VSATLATARIUM — only from inside the author scene editor and the per-story links page. See "Gaps" below.
+- all roles: same view. A-Frame scene viewer; "Interpretive" sidebar (press `I`) showing **accepted** links only; endcap cards to adjacent stories.
+- all roles: can view retired links touching the story in the read-only "Stewardship history" section when such links exist.
+- readers: can follow "Propose an interpretive link" to login; after login, the user returns to `/author/story/:storyId/links#propose`.
 
 ### `/story/manifold` — adjacency grid / link list
 - all roles: view all links and their statuses (proposed / accepted / rejected / retired), filter by pilot, click through to stories.
 
 ### `/story/vsatlatarium` — 3D planetarium
-- all roles: navigate scene and story nodes for published stories, switch planetarium ↔ geomview, hover / click into story detail. No role-gated controls.
+- all roles: navigate scene and story nodes for a selected anthology, switch planetarium ↔ geomview, hover / click into story detail.
+- logged-in users: can propose a link by choosing a source node, target node, type, and rationale in the planetarium panel.
+- readers: can start the proposal flow; if authentication is required, login returns them to the prefilled `/author/story/:storyId/links#propose` fallback.
 
 ## Authenticated pages (`/author/*`)
 
@@ -51,21 +54,21 @@ Unauthenticated hits to guarded paths redirect to `/login`. A logged-in non-owne
 
 ### `/author/story/:storyId` — story editor
 - author (owner only): edit title, CRUD scenes, edit scene content, upload images + audio, publish / unpublish, delete story, **propose link from a scene** (opens propose-link modal), navigate to preview or links.
-- steward (non-owner): bypasses ownership check, so has the same editing powers on any story. This is by design for stewardship, but worth flagging.
-- author (non-owner): redirected away with `Unauthorized`.
+- author / steward (non-owner): redirected away with `Unauthorized`.
 
 ### `/author/story/:storyId/preview` — preview as reader
-- author (owner) and steward: read-only preview of the published shape of the story.
-- author (non-owner): redirected away.
+- author (owner): read-only preview of the published shape of the story.
+- author / steward (non-owner): redirected away.
 
 ### `/author/story/:storyId/links` — links involving this story
-- any logged-in user (ownership **not** required on this sub-route): view inbound + outbound links; propose a new link; accept / reject (vote).
-- steward: additionally retire / unretire. UI exposes the retire/unretire buttons only when `isStewardUser` is true; help text on the page says "Retire/unretire actions are visible to stewards only."
+- any logged-in user (ownership **not** required on this sub-route): view inbound + outbound links; propose a new link.
+- author of a linked story: accept / reject (vote).
+- steward: accept / reject, plus retire / unretire. UI exposes the retire/unretire buttons only when `isStewardUser` is true; help text on the page says "Retire/unretire actions are visible to stewards only."
 
 ### `/author/links` — global link dashboard
-- any logged-in user: review all links site-wide, accept / reject.
+- any logged-in non-steward user: review links touching stories they authored, accept / reject.
+- steward: review all links site-wide, accept / reject.
 - steward: additionally retire / unretire.
-- Known scope issue: currently shows all links, not scoped to the current author's stories (see `docs/qa-checklist.md` P1).
 
 ### `/author/steward` — steward console
 - non-steward logged-in user: page loads with a message "You are not marked as a steward for this environment." No adjudication UI.
@@ -80,12 +83,12 @@ Unauthenticated hits to guarded paths redirect to `/login`. A logged-in non-owne
 | Endpoint | Who | Notes |
 | --- | --- | --- |
 | `POST /api/story/:storyId/links` | any logged-in user | propose a link (status `proposed`). |
-| `POST /api/links/:linkId/vote` | any logged-in user | `{vote: "accept"\|"reject"}`. |
+| `POST /api/links/:linkId/vote` | author of linked story or steward | `{vote: "accept"\|"reject"}`. |
 | `POST /api/links/:linkId/retire` | **steward only** | 403 for non-stewards; toggles to/from `retired`. |
 | `POST /api/pilot` | any logged-in user | create pilot. |
 | `POST /api/pilot/:pilotId/stories` | any logged-in user | attach story to pilot. |
 | `POST /api/pilot/:pilotId/notes` | any logged-in user | add interpretive note. |
-| `GET  /api/pilot/:pilotId/report` | open | JSON report; no auth check on the route itself. |
+| `GET  /api/pilot/:pilotId/report` | any logged-in user | JSON report; the route itself has no extra role check, but `/api/*` is login-gated by middleware. |
 
 Every API action has a UI entry point somewhere in `/author/*`.
 
@@ -98,10 +101,10 @@ Every API action has a UI entry point somewhere in `/author/*`.
 | Use VSATLATARIUM / manifold | ✓ | ✓ | ✓ | ✓ |
 | Read stewardship compact | ✓ | ✓ | ✓ | ✓ |
 | Log in | ✓ | — | — | — |
-| Create / edit / delete own story, scenes, media | — | ✓ | — | ✓ (any story) |
-| Publish / unpublish own story | — | ✓ | — | ✓ (any story) |
+| Create / edit / delete own story, scenes, media | — | ✓ | — | ✓ (own stories only) |
+| Publish / unpublish own story | — | ✓ | — | ✓ (own stories only) |
 | Propose a link | — | ✓ | ✓ | ✓ |
-| Accept / reject a link (vote) | — | ✓ | ✓ | ✓ |
+| Accept / reject a link (vote) | — | ✓ (linked own story) | — | ✓ |
 | Retire / unretire a link | — | — | — | ✓ |
 | Create / manage pilots, notes | — | ✓ | ✓ | ✓ |
 | Use steward console | — | — | — | ✓ |
@@ -119,34 +122,32 @@ flowchart LR
   SR -->|press I| SB["Interpretive sidebar<br/>(accepted links only)"]
   SB --> AS["Adjacent story endcap"]
   AS --> SR2["/story/:otherId"]
+  SR --> PL0["/author/story/:storyId/links#propose<br/>(after login if needed)"]
   SR --> VL["/story/vsatlatarium"]
   SR --> MF["/story/manifold"]
-  SR -.->|empty-state says<br/>&quot;try VSATLATARIUM to propose&quot;| DEAD(["no propose UI here<br/>or in planetarium"]):::gap
-
-  classDef gap fill:#fde,stroke:#c66,color:#633;
 ```
 
-Reader interactions on a photosphere page = read the scene, read accepted interpretive links, jump to adjacent stories, jump to the global views. No write actions.
+Reader interactions on a photosphere page = read the scene, read accepted interpretive links, jump to adjacent stories, jump to the global views, or log in to propose an interpretive link.
 
 ### J2. Reader → Propose a link (the "how do I contribute?" path)
 
 ```mermaid
 flowchart LR
   R([Reader]) --> SR["/story/:storyId"]
-  SR -.->|no propose button| X1(( )):::gap
+  SR -->|Propose interpretive link| LOGIN1["/login?returnTo=..."]
   R --> VL["/story/vsatlatarium"]
-  VL -.->|no propose button| X2(( )):::gap
+  VL -->|Propose from node pair| LOGIN2["/login?returnTo=..."]
   R -->|log in via /login| A([Author])
+  LOGIN1 --> ASL["/author/story/:storyId/links#propose"]
+  LOGIN2 --> ASL
   A --> AE["/author/story/:myStoryId<br/>scene editor"]
   AE -->|&quot;Propose link from here&quot;| PL[[Propose-link modal]]
-  A --> ASL["/author/story/:myStoryId/links"]
+  A --> ASL
   ASL -->|Propose form| PL
   PL -->|POST /api/story/:storyId/links| DB[(status: proposed)]
-
-  classDef gap fill:#fde,stroke:#c66,color:#633;
 ```
 
-Gap: a reader must (a) log in, and (b) have at least one of their own stories to get into a scene editor, because the only propose-link entry points are author-context. The public read page and planetarium invite proposals but do not host the UI.
+Reachability note: a reader must log in before writing, but no longer needs to own a story or enter the scene editor. Public story pages and VSATLATARIUM both lead to the per-story proposal form.
 
 ### J3. Author reviews / votes on links touching their story
 
@@ -155,7 +156,7 @@ flowchart LR
   A([Author, logged in]) --> AD["/author/story/ — dashboard"]
   AD --> AE["/author/story/:storyId"]
   AE -->|Links button| ASL["/author/story/:storyId/links"]
-  AD --> AL["/author/links — global links"]
+  AD --> AL["/author/links — scoped links"]
   ASL -->|Accept / Reject| V1["POST /api/links/:id/vote"]
   AL -->|Accept / Reject| V1
   ASL -.->|Retire/unretire hidden| ST{{steward-only}}:::steward
@@ -164,7 +165,7 @@ flowchart LR
   classDef steward fill:#eef,stroke:#66c,color:#336;
 ```
 
-Note: `/author/story/:storyId/links` is **not** ownership-gated — any logged-in user can open it for any story and vote. Global `/author/links` is likewise open to any logged-in user (see qa-checklist P1).
+Note: `/author/story/:storyId/links` is **not** ownership-gated — any logged-in user can open it for any story and propose a link. Accept/reject voting is restricted to authors of linked stories and stewards. `/author/links` scopes non-stewards to links touching their authored stories; stewards see all links.
 
 ### J4. Steward adjudicates links
 
@@ -177,14 +178,12 @@ flowchart LR
   ASL -->|Retire / unretire<br/>(visible because isStewardUser)| RT
   S --> AL["/author/links"]
   AL -->|Retire / unretire| RT
-  S --> AE["/author/story/:anyStoryId"]:::wide
-  AE -->|bypasses ownership check| EDIT[[can also edit / delete<br/>ANY story]]:::gap
+  S -.->|"non-owned story edit"| DENY["redirect Unauthorized"]:::wide
 
-  classDef gap fill:#fde,stroke:#c66,color:#633;
   classDef wide fill:#ffd,stroke:#c90,color:#630;
 ```
 
-Three surfaces for retire/unretire (console, per-story links, global links). Side-effect worth reviewing: `assertAuthorMiddleware` lets stewards through, so the steward role currently includes full content-edit power on any story, not just link adjudication.
+Three surfaces for retire/unretire (console, per-story links, scoped/global links). Stewards do not get global story edit/delete authority.
 
 ### J5. How do I add a new steward?
 
@@ -211,19 +210,17 @@ There is no self-service promotion flow. Adding a steward in production = editin
 
 ```mermaid
 flowchart LR
-  V["/story/vsatlatarium"] -->|click scene node| SR["/story/:storyId"]
-  SR -->|log in, navigate to own story| AE["/author/story/:myStoryId"]
-  AE --> PL[[Propose-link modal]]
+  V["/story/vsatlatarium"] -->|pick source node| SRC["source selected"]
+  SRC -->|pick target node| TGT["target selected"]
+  TGT -->|submit in panel| PL[[POST proposal]]
+  TGT -->|needs login| ASL["/author/story/:sourceId/links#propose<br/>(prefilled fallback)"]
   PL --> DB[(link: proposed)]
   DB -.->|planetarium shows<br/>proposed as dim arcs| V
   DB -->|accept vote| ACC[(link: accepted)]
   ACC -->|bright arc| V
-  V -.->|no &quot;add link&quot; control<br/>in planetarium itself| GAP(( )):::gap
-
-  classDef gap fill:#fde,stroke:#c66,color:#633;
 ```
 
-Round-trip works but is indirect: planetarium → story page → log in → own story editor → propose → (optionally vote to accept) → arcs update next planetarium load. There is no in-planetarium "add link between these two nodes I just clicked" affordance.
+Round-trip now works directly for logged-in users from the planetarium panel. Unauthenticated users are sent through login and land on the prefilled per-story proposal form.
 
 ### J7. Full role × surface map (reference)
 
@@ -250,8 +247,8 @@ flowchart TB
 
   subgraph Authed["/author/* (login required)"]
     AD["/author/story/"]:::auth
-    AE["/author/story/:id<br/>(owner or steward)"]:::auth
-    PRE["/author/story/:id/preview<br/>(owner or steward)"]:::auth
+    AE["/author/story/:id<br/>(owner only)"]:::auth
+    PRE["/author/story/:id/preview<br/>(owner only)"]:::auth
     ASL["/author/story/:id/links<br/>(any logged-in)"]:::auth
     AL["/author/links<br/>(any logged-in)"]:::auth
     PI["/author/pilot/*"]:::auth
@@ -280,9 +277,9 @@ flowchart TB
 
 ## Reachability gaps and questions worth auditing
 
-- **Reader → Propose link**: page copy on `/story/:storyId` invites readers to "propose one" via VSATLATARIUM, but propose UI is only reachable through `/author/story/:storyId` (scene editor) and `/author/story/:storyId/links`. A reader who follows the prompt lands nowhere. Either drop the copy, surface a propose modal on the public read page (login-gated at submit), or add propose UI to VSATLATARIUM.
-- **Steward global edit power**: stewards bypass `assertAuthorMiddleware`, so they can edit/publish/delete any story, not just adjudicate links. Intentional? The stewardship compact frames stewards as link adjudicators, not content editors.
-- **`/author/links` scope**: shows all links site-wide to every logged-in user — effectively makes every logged-in user a global link reviewer. Known issue (qa-checklist P1); decide whether it should be author-scoped, steward-only, or renamed.
-- **`/author/story/:storyId/links` has no ownership gate**: any logged-in user can vote on links for any story. Probably correct (voting is a community action), but worth confirming versus "only authors of either endpoint story can vote."
-- **Pilot report `GET /api/pilot/:pilotId/report`** is unauthenticated. Intentional (public share link)? If yes, document it; if no, add the login gate.
-- **No non-steward path to see retired links** on the public read page — retired links are hidden from readers. If stewardship is meant to be transparent, consider showing "retired" with the rationale visible.
+- **Reader → Propose link**: addressed by the public story "Propose an interpretive link" CTA, VSATLATARIUM's source/target proposal panel, and `returnTo` login redirects into `/author/story/:storyId/links#propose`. Continue QA on the Magic-link round trip and prefilled target fields.
+- **Steward global edit power**: addressed by removing steward ownership bypass from story edit/preview routes. Steward powers are now link-adjudication powers, not global content edit powers.
+- **`/author/links` scope**: addressed in the UI by showing all links only to stewards and scoping non-stewards to links that touch their authored stories.
+- **`/author/story/:storyId/links` vote scope**: addressed by keeping viewing/proposal open to logged-in users while restricting accept/reject votes to authors of linked stories and stewards, including direct API calls.
+- **Pilot report `GET /api/pilot/:pilotId/report`**: documented as login-gated by the shared `/api/*` middleware. If public share links are desired later, that should be an explicit route/config decision.
+- **No non-steward path to see retired links**: addressed by showing retired links and rationale in a read-only "Stewardship history" section on public story pages.

--- a/src/authentication/authenticationRequired.ts
+++ b/src/authentication/authenticationRequired.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from "express";
 import type { Logger } from "pino";
 
 import type { AuthenticationConfig } from "../environment/config.js";
+import { loginPathForReturnTo } from "./returnTo.js";
 
 /**
  * Build (Express) middleware that guards paths requiring an authenticated user.
@@ -30,7 +31,7 @@ export default function authenticationRequired(
     if (requiresAuth(path)) {
       log.trace({ path }, "Request requires authenticated user");
 
-      return res.redirect("/login");
+      return res.redirect(loginPathForReturnTo(req.originalUrl || req.url));
     }
 
     log.trace({ path }, "Request does not require authenticated user");

--- a/src/authentication/client/authenticateWithServerUsingEmail.ts
+++ b/src/authentication/client/authenticateWithServerUsingEmail.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { Magic } from "magic-sdk";
-
+import { safeReturnTo } from "../returnTo.js";
 import authenticateWithServer from "./authenticateWithServer.js";
 
 const LIFESPAN_IN_SECONDS = 2 /* hours */ * 60 * 60;
@@ -10,11 +10,15 @@ const LIFESPAN_IN_SECONDS = 2 /* hours */ * 60 * 60;
 async function authenticateWithServerUsingEmail(
   publicKey: string,
   email: string,
+  returnTo?: string,
 ) {
   const magic = new Magic(publicKey);
+  const callbackUrl = new URL("/login/callback", window.location.origin);
+  callbackUrl.searchParams.set("returnTo", safeReturnTo(returnTo));
+
   const token = await magic.auth.loginWithMagicLink({
     email,
-    redirectURI: new URL("/login/callback", window.location.origin).href,
+    redirectURI: callbackUrl.href,
     lifespan: LIFESPAN_IN_SECONDS,
   });
 

--- a/src/authentication/returnTo.ts
+++ b/src/authentication/returnTo.ts
@@ -1,0 +1,23 @@
+const DEFAULT_RETURN_TO = "/author/story";
+
+export function safeReturnTo(value: string | null | undefined): string {
+  if (!value) {
+    return DEFAULT_RETURN_TO;
+  }
+
+  try {
+    const decoded = decodeURIComponent(value);
+    if (!decoded.startsWith("/") || decoded.startsWith("//")) {
+      return DEFAULT_RETURN_TO;
+    }
+
+    return decoded;
+  } catch {
+    return DEFAULT_RETURN_TO;
+  }
+}
+
+export function loginPathForReturnTo(returnTo: string): string {
+  const safePath = safeReturnTo(returnTo);
+  return `/login?returnTo=${encodeURIComponent(safePath)}`;
+}

--- a/src/components/authentication/Login.tsx
+++ b/src/components/authentication/Login.tsx
@@ -3,6 +3,7 @@ import { type FC, type PropsWithChildren, useState } from "react";
 import { I18nextProvider } from "react-i18next";
 
 import authenticateWithServerUsingEmail from "../../authentication/client/authenticateWithServerUsingEmail.js";
+import { safeReturnTo } from "../../authentication/returnTo.js";
 import useI18N from "../../i18n/client/useI18N.js";
 import LoginForm, { type OnLogin } from "./LoginForm.js";
 
@@ -16,15 +17,18 @@ type LoginState =
  */
 type LoginProps = PropsWithChildren & {
   magicPublicKey: string;
+  returnTo: string;
   translations: Record<string, ResourceKey>;
 };
 
 const Login: FC<LoginProps> = ({
   magicPublicKey,
+  returnTo,
   translations,
   children: loginInProgress,
 }) => {
   const i18n = useI18N(translations, navigator.language);
+  const safeRedirectPath = safeReturnTo(returnTo);
 
   const [loginState, setLoginState] = useState<LoginState>({
     kind: "loginForm",
@@ -33,10 +37,10 @@ const Login: FC<LoginProps> = ({
   const onLogin: OnLogin = (email) => {
     setLoginState({ kind: "loginInProgress" });
 
-    authenticateWithServerUsingEmail(magicPublicKey, email)
+    authenticateWithServerUsingEmail(magicPublicKey, email, safeRedirectPath)
       .then(() => {
         window.location.href = new URL(
-          "author/story",
+          safeRedirectPath,
           window.location.origin,
         ).href;
       })

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -7,6 +7,8 @@ import devAuthBypass from "./authentication/devAuthBypass.js";
 import passportWithMagicLogin from "./authentication/passport/passportWithMagicLogin.js";
 import routeAuthenticate from "./authentication/routeAuthenticate.js";
 import routeLogout from "./authentication/routeLogout.js";
+import routePilot from "./domain/pilot/route/routePilot.js";
+import canVoteOnStoryLinkInDatabase from "./domain/story/link/canVoteOnStoryLinkInDatabase.js";
 import routeCreateScene from "./domain/story/route/routeCreateScene.js";
 import routeCreateStory from "./domain/story/route/routeCreateStory.js";
 import routeDeleteScene from "./domain/story/route/routeDeleteScene.js";
@@ -16,7 +18,6 @@ import routeDeleteStory from "./domain/story/route/routeDeleteStory.js";
 import routeGetPublishedStories from "./domain/story/route/routeGetPublishedStories.js";
 import routeGetScene from "./domain/story/route/routeGetScene.js";
 import routeGetStory from "./domain/story/route/routeGetStory.js";
-import routePilot from "./domain/pilot/route/routePilot.js";
 import routePublishStory from "./domain/story/route/routePublishStory.js";
 import routeSaveAuthorName from "./domain/story/route/routeSaveAuthorName.js";
 import routeSaveSceneContent from "./domain/story/route/routeSaveSceneContent.js";
@@ -184,6 +185,7 @@ export async function createAppParts(): Promise<{
       repositoryStoryLink.createStoryLink,
       repositoryStoryLink.getStoryLinksForStory,
       repositoryStoryLink.voteOnStoryLink,
+      canVoteOnStoryLinkInDatabase(() => db),
       repositoryStoryLink.retireStoryLink,
     ),
     routePilot(

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -215,6 +215,8 @@ export type StoryLinkSummary = {
   status: StoryLinkStatus;
   createdBy: Pick<AuthorDto, "id" | "name">;
   createdAt: Date;
+  acceptedAt?: Date | null;
+  rejectedAt?: Date | null;
 };
 
 export type CreateStoryLinkRequest = {

--- a/src/domain/story/link/canVoteOnStoryLinkInDatabase.ts
+++ b/src/domain/story/link/canVoteOnStoryLinkInDatabase.ts
@@ -1,0 +1,45 @@
+import type {
+  AuthorDto,
+  GetDatabase,
+  StoryDto,
+} from "../../../database/schema.js";
+
+export type CanVoteOnStoryLinkRequest = {
+  linkId: number;
+  userId: AuthorDto["id"];
+  isSteward: boolean;
+};
+
+export type CanVoteOnStoryLink = (
+  request: CanVoteOnStoryLinkRequest,
+) => Promise<boolean>;
+
+export default function canVoteOnStoryLinkInDatabase(
+  db: GetDatabase,
+): CanVoteOnStoryLink {
+  return async ({ linkId, userId, isSteward }) => {
+    if (isSteward) {
+      return true;
+    }
+
+    const link = await db()
+      .selectFrom("storyLink")
+      .select(["fromStoryId", "toStoryId"])
+      .where("storyLink.id", "=", linkId)
+      .executeTakeFirst();
+
+    if (!link) {
+      return false;
+    }
+
+    const storyIds: StoryDto["id"][] = [link.fromStoryId, link.toStoryId];
+    const authoredStory = await db()
+      .selectFrom("authorToStory")
+      .select("storyId")
+      .where("authorToStory.authorId", "=", userId)
+      .where("authorToStory.storyId", "in", storyIds)
+      .executeTakeFirst();
+
+    return authoredStory !== undefined;
+  };
+}

--- a/src/domain/story/link/createStoryLinkInDatabase.ts
+++ b/src/domain/story/link/createStoryLinkInDatabase.ts
@@ -32,7 +32,7 @@ export default function createStoryLinkInDatabase(
       .innerJoin("story as toStory", "toStory.id", "storyLink.toStoryId")
       .leftJoin("scene as toScene", "toScene.id", "storyLink.toSceneId")
       .innerJoin("author as creator", "creator.id", "storyLink.createdBy")
-      .select([
+      .select((eb) => [
         "storyLink.id as id",
         "storyLink.linkType as linkType",
         "storyLink.rationale as rationale",
@@ -47,6 +47,18 @@ export default function createStoryLinkInDatabase(
         "storyLink.toPageNumber as toPageNumber",
         "creator.id as createdById",
         "creator.name as createdByName",
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("acceptedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "accept")
+          .as("acceptedAt"),
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("rejectedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "reject")
+          .as("rejectedAt"),
       ])
       .where("storyLink.id", "=", inserted.id)
       .executeTakeFirstOrThrow();

--- a/src/domain/story/link/getAllStoryLinksInDatabase.ts
+++ b/src/domain/story/link/getAllStoryLinksInDatabase.ts
@@ -17,7 +17,7 @@ export default function getAllStoryLinksInDatabase(
       .innerJoin("story as toStory", "toStory.id", "storyLink.toStoryId")
       .leftJoin("scene as toScene", "toScene.id", "storyLink.toSceneId")
       .innerJoin("author as creator", "creator.id", "storyLink.createdBy")
-      .select([
+      .select((eb) => [
         "storyLink.id as id",
         "storyLink.linkType as linkType",
         "storyLink.rationale as rationale",
@@ -32,6 +32,18 @@ export default function getAllStoryLinksInDatabase(
         "storyLink.toPageNumber as toPageNumber",
         "creator.id as createdById",
         "creator.name as createdByName",
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("acceptedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "accept")
+          .as("acceptedAt"),
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("rejectedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "reject")
+          .as("rejectedAt"),
       ])
       .orderBy("storyLink.createdAt", "desc")
       .execute();

--- a/src/domain/story/link/getStoryLinksForStoryInDatabase.ts
+++ b/src/domain/story/link/getStoryLinksForStoryInDatabase.ts
@@ -17,7 +17,7 @@ export default function getStoryLinksForStoryInDatabase(
       .innerJoin("story as toStory", "toStory.id", "storyLink.toStoryId")
       .leftJoin("scene as toScene", "toScene.id", "storyLink.toSceneId")
       .innerJoin("author as creator", "creator.id", "storyLink.createdBy")
-      .select([
+      .select((eb) => [
         "storyLink.id as id",
         "storyLink.linkType as linkType",
         "storyLink.rationale as rationale",
@@ -32,6 +32,18 @@ export default function getStoryLinksForStoryInDatabase(
         "storyLink.toPageNumber as toPageNumber",
         "creator.id as createdById",
         "creator.name as createdByName",
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("acceptedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "accept")
+          .as("acceptedAt"),
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("rejectedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "reject")
+          .as("rejectedAt"),
       ])
       .where((eb) =>
         eb.or([

--- a/src/domain/story/link/mapStoryLinkSummary.ts
+++ b/src/domain/story/link/mapStoryLinkSummary.ts
@@ -6,6 +6,8 @@ type StoryLinkRow = {
   rationale: string;
   status: string;
   createdAt: Date;
+  acceptedAt: Date | null;
+  rejectedAt: Date | null;
   fromStoryId: number;
   fromStoryTitle: string;
   toStoryId: number;
@@ -24,6 +26,8 @@ export function mapStoryLinkSummary(row: StoryLinkRow): StoryLinkSummary {
     rationale: row.rationale,
     status: row.status as StoryLinkSummary["status"],
     createdAt: row.createdAt,
+    acceptedAt: row.acceptedAt,
+    rejectedAt: row.rejectedAt,
     fromStory: {
       id: row.fromStoryId,
       title: row.fromStoryTitle,

--- a/src/domain/story/link/retireStoryLinkInDatabase.ts
+++ b/src/domain/story/link/retireStoryLinkInDatabase.ts
@@ -31,7 +31,7 @@ export default function retireStoryLinkInDatabase(
       .innerJoin("story as toStory", "toStory.id", "storyLink.toStoryId")
       .leftJoin("scene as toScene", "toScene.id", "storyLink.toSceneId")
       .innerJoin("author as creator", "creator.id", "storyLink.createdBy")
-      .select([
+      .select((eb) => [
         "storyLink.id as id",
         "storyLink.linkType as linkType",
         "storyLink.rationale as rationale",
@@ -46,6 +46,18 @@ export default function retireStoryLinkInDatabase(
         "storyLink.toPageNumber as toPageNumber",
         "creator.id as createdById",
         "creator.name as createdByName",
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("acceptedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "accept")
+          .as("acceptedAt"),
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("rejectedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "reject")
+          .as("rejectedAt"),
       ])
       .where("storyLink.id", "=", request.linkId)
       .executeTakeFirstOrThrow();

--- a/src/domain/story/link/voteOnStoryLinkInDatabase.ts
+++ b/src/domain/story/link/voteOnStoryLinkInDatabase.ts
@@ -1,7 +1,6 @@
-import type { Logger } from "pino";
-
-import type { GetDatabase } from "../../../database/schema.js";
 import { sql } from "kysely";
+import type { Logger } from "pino";
+import type { GetDatabase } from "../../../database/schema.js";
 import type { VoteOnStoryLink, VoteOnStoryLinkResult } from "../../index.js";
 import { mapStoryLinkSummary } from "./mapStoryLinkSummary.js";
 
@@ -89,7 +88,7 @@ export default function voteOnStoryLinkInDatabase(
       .innerJoin("story as toStory", "toStory.id", "storyLink.toStoryId")
       .leftJoin("scene as toScene", "toScene.id", "storyLink.toSceneId")
       .innerJoin("author as creator", "creator.id", "storyLink.createdBy")
-      .select([
+      .select((eb) => [
         "storyLink.id as id",
         "storyLink.linkType as linkType",
         "storyLink.rationale as rationale",
@@ -104,6 +103,18 @@ export default function voteOnStoryLinkInDatabase(
         "storyLink.toPageNumber as toPageNumber",
         "creator.id as createdById",
         "creator.name as createdByName",
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("acceptedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "accept")
+          .as("acceptedAt"),
+        eb
+          .selectFrom("linkVote")
+          .select((eb) => eb.fn.max("linkVote.createdAt").as("rejectedAt"))
+          .whereRef("linkVote.linkId", "=", "storyLink.id")
+          .where("linkVote.vote", "=", "reject")
+          .as("rejectedAt"),
       ])
       .where("storyLink.id", "=", request.linkId)
       .executeTakeFirstOrThrow();

--- a/src/domain/story/route/routeStoryLinks.ts
+++ b/src/domain/story/route/routeStoryLinks.ts
@@ -1,23 +1,24 @@
 import express, { type RequestHandler, Router } from "express";
 import { z } from "zod";
-
+import isStewardUser from "../../../authentication/isStewardUser.js";
 import { ErrorCodes } from "../../error/errorCode.js";
 import { errorCodedContext } from "../../error/errorCodedContext.js";
-import isStewardUser from "../../../authentication/isStewardUser.js";
 import {
-  LinkVoteValues,
-  StoryLinkStatuses,
-  StoryLinkTypes,
   type CreateStoryLink,
   type GetStoryLinksForStory,
+  LinkVoteValues,
   type RetireStoryLink,
+  StoryLinkStatuses,
+  StoryLinkTypes,
   type VoteOnStoryLink,
 } from "../../index.js";
+import type { CanVoteOnStoryLink } from "../link/canVoteOnStoryLinkInDatabase.js";
 
 function routeStoryLinks(
   createStoryLink: CreateStoryLink,
   getStoryLinksForStory: GetStoryLinksForStory,
   voteOnStoryLink: VoteOnStoryLink,
+  canVoteOnStoryLink: CanVoteOnStoryLink,
   retireStoryLink: RetireStoryLink,
   ...otherHandlers: RequestHandler[]
 ): Router {
@@ -52,24 +53,24 @@ function routeStoryLinks(
         return;
       }
 
-    const parseResult = CreateStoryLinkRequestModel.safeParse({
-      storyId: req.params.storyId,
-      toStoryId: req.body?.toStoryId,
-      toSceneId: req.body?.toSceneId,
-      toPageNumber: req.body?.toPageNumber,
-      linkType: req.body?.linkType,
-      rationale: req.body?.rationale,
-    });
+      const parseResult = CreateStoryLinkRequestModel.safeParse({
+        storyId: req.params.storyId,
+        toStoryId: req.body?.toStoryId,
+        toSceneId: req.body?.toSceneId,
+        toPageNumber: req.body?.toPageNumber,
+        linkType: req.body?.linkType,
+        rationale: req.body?.rationale,
+      });
 
-    if (!parseResult.success) {
-      res.status(400).json(errorCodedContext(ErrorCodes.BadRequest));
-      return;
-    }
+      if (!parseResult.success) {
+        res.status(400).json(errorCodedContext(ErrorCodes.BadRequest));
+        return;
+      }
 
-    if (parseResult.data.storyId === parseResult.data.toStoryId) {
-      res.status(400).json(errorCodedContext(ErrorCodes.BadRequest));
-      return;
-    }
+      if (parseResult.data.storyId === parseResult.data.toStoryId) {
+        res.status(400).json(errorCodedContext(ErrorCodes.BadRequest));
+        return;
+      }
 
       createStoryLink({
         fromStoryId: parseResult.data.storyId,
@@ -89,36 +90,52 @@ function routeStoryLinks(
     },
   );
 
-  router.post("/links/:linkId/vote", ...(otherHandlers ?? []), express.json(), (req, res) => {
-    if (!req.user) {
-      res.status(401).json(errorCodedContext(ErrorCodes.Unauthorized));
-      return;
-    }
+  router.post(
+    "/links/:linkId/vote",
+    ...(otherHandlers ?? []),
+    express.json(),
+    async (req, res) => {
+      if (!req.user) {
+        res.status(401).json(errorCodedContext(ErrorCodes.Unauthorized));
+        return;
+      }
 
-    const parseResult = VoteOnStoryLinkRequestModel.safeParse({
-      linkId: req.params.linkId,
-      vote: req.body?.vote,
-      comment: req.body?.comment,
-    });
-
-    if (!parseResult.success) {
-      res.status(400).json(errorCodedContext(ErrorCodes.BadRequest));
-      return;
-    }
-
-    voteOnStoryLink({
-      linkId: parseResult.data.linkId,
-      userId: req.user.id,
-      vote: parseResult.data.vote,
-      comment: parseResult.data.comment,
-    })
-      .then((result) => {
-        res.status(200).json(result);
-      })
-      .catch((err) => {
-        res.status(500).json(errorCodedContext(ErrorCodes.Error, err));
+      const parseResult = VoteOnStoryLinkRequestModel.safeParse({
+        linkId: req.params.linkId,
+        vote: req.body?.vote,
+        comment: req.body?.comment,
       });
-  });
+
+      if (!parseResult.success) {
+        res.status(400).json(errorCodedContext(ErrorCodes.BadRequest));
+        return;
+      }
+
+      const canVote = await canVoteOnStoryLink({
+        linkId: parseResult.data.linkId,
+        userId: req.user.id,
+        isSteward: isStewardUser(req.user, req.headers.cookie),
+      });
+
+      if (!canVote) {
+        res.status(403).json(errorCodedContext(ErrorCodes.Unauthorized));
+        return;
+      }
+
+      voteOnStoryLink({
+        linkId: parseResult.data.linkId,
+        userId: req.user.id,
+        vote: parseResult.data.vote,
+        comment: parseResult.data.comment,
+      })
+        .then((result) => {
+          res.status(200).json(result);
+        })
+        .catch((err) => {
+          res.status(500).json(errorCodedContext(ErrorCodes.Error, err));
+        });
+    },
+  );
 
   router.post("/links/:linkId/retire", ...(otherHandlers ?? []), (req, res) => {
     if (!req.user) {

--- a/src/domain/story/support/assertAuthorMiddleware.ts
+++ b/src/domain/story/support/assertAuthorMiddleware.ts
@@ -3,7 +3,6 @@ import type { MiddlewareHandler } from "astro";
 import { ErrorCodes } from "../../error/errorCode.js";
 import toStoryId from "../toStoryId.js";
 import isAuthorOfTheStory from "./isAuthorOfTheStory.js";
-import isStewardUser from "../../../authentication/isStewardUser.js";
 
 /**
  * Astro middleware asserting that the current user is the author of the story.
@@ -31,15 +30,6 @@ const assertAuthorMiddleware: MiddlewareHandler = async (context, next) => {
   }
 
   if (context.routePattern.endsWith("/links")) {
-    return next();
-  }
-
-  if (
-    isStewardUser(
-      context.locals.user,
-      context.request.headers.get("cookie"),
-    )
-  ) {
     return next();
   }
 

--- a/src/pages/author/links.astro
+++ b/src/pages/author/links.astro
@@ -1,27 +1,60 @@
 ---
-import Layout from "@layouts/AuthoringLayout.astro";
 import isStewardUser from "@authentication/isStewardUser";
+import Layout from "@layouts/AuthoringLayout.astro";
 
 export const prerender = false;
 
-const { repositoryStoryLink, i18n } = Astro.locals.environment<
-  App.WithStoryLinkRepository & App.WithI18N
+const { repositoryStory, repositoryStoryLink, i18n } = Astro.locals.environment<
+  App.WithStoryRepository & App.WithStoryLinkRepository & App.WithI18N
 >();
 
-const links = await repositoryStoryLink.getAllStoryLinks();
 const isSteward = isStewardUser(
   Astro.locals.user,
   Astro.request.headers.get("cookie"),
 );
+const allLinks = await repositoryStoryLink.getAllStoryLinks();
+const authorStories = Astro.locals.user
+  ? await repositoryStory.getStorySummariesByAuthor(Astro.locals.user.id)
+  : null;
+const authorStoryIds = new Set(
+  authorStories?.stories.map((story) => story.id) ?? [],
+);
+const links = isSteward
+  ? allLinks
+  : allLinks.filter(
+      (link) =>
+        authorStoryIds.has(link.fromStory.id) ||
+        authorStoryIds.has(link.toStory.id),
+    );
+const linkDateFormatter = new Intl.DateTimeFormat("en-GB", {
+  dateStyle: "medium",
+});
+const formatLinkDate = (date: Date) => linkDateFormatter.format(date);
+const linkDecisionDate = (link: (typeof links)[number]) => {
+  if (link.status === "accepted" && link.acceptedAt) {
+    return `Accepted ${formatLinkDate(link.acceptedAt)}`;
+  }
+  if (link.status === "rejected" && link.rejectedAt) {
+    return `Rejected ${formatLinkDate(link.rejectedAt)}`;
+  }
+  return null;
+};
 ---
 
-<Layout title="All story links" description={i18n.t("page.story.meta.description")}>
+<Layout
+  title={isSteward ? "All story links" : "Your story links"}
+  description={i18n.t("page.story.meta.description")}
+>
   <main class="links-page">
     <header class="links-header">
       <div>
         <p class="links-kicker">Interpretive layer</p>
-        <h1>All story links</h1>
-        <p class="links-help">Review proposed, accepted, or retired links.</p>
+        <h1>{isSteward ? "All story links" : "Your story links"}</h1>
+        <p class="links-help">
+          {isSteward
+            ? "Review proposed, accepted, or retired links site-wide."
+            : "Review links that touch stories you authored."}
+        </p>
       </div>
       <a href="/author/story/">Back to stories</a>
     </header>
@@ -35,6 +68,12 @@ const isSteward = isStewardUser(
                 <span class="link-type">{link.linkType}</span>
                 <span class="link-status">{link.status}</span>
               </div>
+              <p class="link-date">
+                Proposed {formatLinkDate(link.createdAt)} by {link.createdBy.name}
+              </p>
+              {linkDecisionDate(link) && (
+                <p class="link-date">{linkDecisionDate(link)}</p>
+              )}
               <div class="link-main">
                 <strong>{link.fromStory.title}</strong>
                 <span class="link-arrow">→</span>
@@ -85,12 +124,7 @@ const isSteward = isStewardUser(
           ))}
         </ul>
       ) : (
-        <p>No links yet.</p>
-      )}
-      {!isSteward && (
-        <p class="links-note">
-          Retire/unretire actions are visible to stewards only.
-        </p>
+        <p>{isSteward ? "No links yet." : "No links for your stories yet."}</p>
       )}
     </section>
   </main>
@@ -206,6 +240,12 @@ const isSteward = isStewardUser(
     align-items: center;
   }
 
+  .link-date {
+    margin-top: 0.35rem;
+    font-size: 0.85rem;
+    opacity: 0.75;
+  }
+
   .link-arrow {
     font-weight: bold;
   }
@@ -226,12 +266,6 @@ const isSteward = isStewardUser(
     margin-top: 0.75rem;
     display: flex;
     gap: 0.5rem;
-  }
-
-  .links-note {
-    margin-top: 1rem;
-    font-size: 0.9rem;
-    opacity: 0.7;
   }
 
   .link-action {

--- a/src/pages/author/steward.astro
+++ b/src/pages/author/steward.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from "@layouts/AuthoringLayout.astro";
 import isStewardUser from "@authentication/isStewardUser";
+import Layout from "@layouts/AuthoringLayout.astro";
 
 export const prerender = false;
 
@@ -16,6 +16,19 @@ const isSteward = isStewardUser(
 const stewardToggleEnabled =
   process.env.DEV_STEWARD_TOGGLE === "1" ||
   process.env.DEV_STEWARD_TOGGLE === "true";
+const linkDateFormatter = new Intl.DateTimeFormat("en-GB", {
+  dateStyle: "medium",
+});
+const formatLinkDate = (date: Date) => linkDateFormatter.format(date);
+const linkDecisionDate = (link: (typeof links)[number]) => {
+  if (link.status === "accepted" && link.acceptedAt) {
+    return `Accepted ${formatLinkDate(link.acceptedAt)}`;
+  }
+  if (link.status === "rejected" && link.rejectedAt) {
+    return `Rejected ${formatLinkDate(link.rejectedAt)}`;
+  }
+  return null;
+};
 ---
 
 <Layout title="Steward console" description={i18n.t("page.story.meta.description")}>
@@ -51,8 +64,7 @@ const stewardToggleEnabled =
           <table class="steward-table">
             <thead>
               <tr>
-                <th>Status</th>
-                <th>Type</th>
+                <th>Details</th>
                 <th>From</th>
                 <th>To</th>
                 <th>Rationale</th>
@@ -62,9 +74,25 @@ const stewardToggleEnabled =
             <tbody id="steward-links">
               {links.map((link) => (
                 <tr data-link-id={link.id}>
-                  <td class="status">{link.status}</td>
-                  <td>{link.linkType}</td>
-                  <td>{link.fromStory.title}</td>
+                  <td class="link-details">
+                    <span class={`status status--${link.status}`}>
+                      {link.status}
+                    </span>
+                    <span>Proposed {formatLinkDate(link.createdAt)}</span>
+                    {linkDecisionDate(link) && (
+                      <span>{linkDecisionDate(link)}</span>
+                    )}
+                  </td>
+                  <td class="from-cell">
+                    <span class="from-cell__inner">
+                      <span>{link.fromStory.title}</span>
+                      <span
+                        class={`link-type-chip link-type-chip--${link.linkType}`}
+                      >
+                        {link.linkType}
+                      </span>
+                    </span>
+                  </td>
                   <td>
                     {link.toStory.title}
                     {link.toScene && (
@@ -109,7 +137,10 @@ const stewardToggleEnabled =
         if (!res.ok) return;
         const data = await res.json();
         const statusCell = row?.querySelector(".status");
-        if (statusCell) statusCell.textContent = data.status;
+        if (statusCell) {
+          statusCell.textContent = data.status;
+          statusCell.className = `status status--${data.status}`;
+        }
         button.textContent = data.status === "retired" ? "Unretire" : "Retire";
       });
     </script>
@@ -166,6 +197,82 @@ const stewardToggleEnabled =
     max-width: 280px;
   }
 
+  .link-details {
+    display: grid;
+    justify-items: start;
+    gap: 0.25rem;
+    min-width: 9rem;
+  }
+
+  .from-cell__inner {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: space-between;
+    align-items: flex-start;
+  }
+
+  .status,
+  .link-type-chip {
+    display: inline-block;
+    padding: 0.12rem 0.5rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1.2;
+    text-transform: uppercase;
+  }
+
+  .status {
+    border-radius: 0.15rem;
+    border: 1px solid #6c757d;
+    background: #fff;
+    color: #343a40;
+  }
+
+  .link-type-chip {
+    border-radius: 999px;
+  }
+
+  .status--accepted {
+    border-color: #495057;
+  }
+
+  .status--proposed {
+    border-color: #6c757d;
+  }
+
+  .status--rejected {
+    border-color: #495057;
+  }
+
+  .status--retired {
+    border-color: #6c757d;
+  }
+
+  .link-type-chip {
+    border: 1px solid currentColor;
+    background: #fff;
+  }
+
+  .link-type-chip--thematic {
+    color: #7e3ab8;
+    background: #f3e8ff;
+  }
+
+  .link-type-chip--causal {
+    color: #b91c1c;
+    background: #fee2e2;
+  }
+
+  .link-type-chip--adjacency {
+    color: #047857;
+    background: #d1fae5;
+  }
+
+  .link-type-chip--contrast {
+    color: #be185d;
+    background: #fce7f3;
+  }
+
   .route {
     display: inline-block;
     margin-left: 0.25rem;
@@ -199,17 +306,20 @@ const stewardToggleEnabled =
     transition: background 0.2s ease;
   }
 
-  .steward-table tbody tr:hover {
-    background: #f0f7ff;
+  .steward-table tbody tr:nth-child(odd) {
+    background: #fff;
   }
 
-  /* Alternating row colors */
   .steward-table tbody tr:nth-child(even) {
-    background: #fafafa;
+    background: #e6e6e6;
+  }
+
+  .steward-table tbody tr:hover {
+    background: #e7f2ff;
   }
 
   .steward-table tbody tr:nth-child(even):hover {
-    background: #f0f7ff;
+    background: #e7f2ff;
   }
 
   /* Code element styling */

--- a/src/pages/author/story/[storyId]/links.astro
+++ b/src/pages/author/story/[storyId]/links.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from "@layouts/AuthoringLayout.astro";
 import isStewardUser from "@authentication/isStewardUser";
 import { ErrorCodes } from "@domain/error/errorCode";
 import toStoryId from "@domain/story/toStoryId";
+import Layout from "@layouts/AuthoringLayout.astro";
 
 export const prerender = false;
 
@@ -25,12 +25,58 @@ if (!story) {
 const links = await repositoryStoryLink.getStoryLinksForStory(storyId);
 const publishedStories = await repositoryStory.getPublishedStorySummaries({});
 const otherStories = publishedStories.filter((s) => s.id !== storyId);
+const authorStories = Astro.locals.user
+  ? await repositoryStory.getStorySummariesByAuthor(Astro.locals.user.id)
+  : null;
+const authorStoryIds = new Set(
+  authorStories?.stories.map((story) => story.id) ?? [],
+);
 const isSteward = isStewardUser(
   Astro.locals.user,
   Astro.request.headers.get("cookie"),
 );
+const canEditStory = authorStoryIds.has(storyId);
+const canVoteOnLinks = isSteward || canEditStory;
+const publicStoryHref = `/story/${story.id}`;
+const returnTo = Astro.url.searchParams.get("returnTo");
+const returningToPublicStory = returnTo === publicStoryHref;
+const storyReturnHref = canEditStory
+  ? `/author/story/${story.id}`
+  : publicStoryHref;
+const storyReturnLabel = canEditStory
+  ? "Back to story editor"
+  : returningToPublicStory
+    ? "Back to story"
+    : "Read story";
 const contextSceneId = Astro.url.searchParams.get("contextSceneId");
 const contextPageNumber = Astro.url.searchParams.get("contextPageNumber");
+const prefillToStoryId = Astro.url.searchParams.get("toStoryId");
+const prefillToSceneId = Astro.url.searchParams.get("toSceneId");
+const prefillToPageNumber = Astro.url.searchParams.get("toPageNumber");
+const prefillLinkType = Astro.url.searchParams.get("linkType") ?? "thematic";
+const linkStatusRank = {
+  accepted: 0,
+  proposed: 1,
+  rejected: 2,
+  retired: 3,
+} as const;
+const linkDateFormatter = new Intl.DateTimeFormat("en-GB", {
+  dateStyle: "medium",
+});
+const formatLinkDate = (date: Date) => linkDateFormatter.format(date);
+const linkDecisionDate = (link: (typeof links)[number]) => {
+  if (link.status === "accepted" && link.acceptedAt) {
+    return `Accepted ${formatLinkDate(link.acceptedAt)}`;
+  }
+  if (link.status === "rejected" && link.rejectedAt) {
+    return `Rejected ${formatLinkDate(link.rejectedAt)}`;
+  }
+  return null;
+};
+const sortedLinks = [...links].sort((a, b) => {
+  const statusDelta = linkStatusRank[a.status] - linkStatusRank[b.status];
+  return statusDelta || b.createdAt.getTime() - a.createdAt.getTime();
+});
 ---
 
 <Layout
@@ -47,132 +93,177 @@ const contextPageNumber = Astro.url.searchParams.get("contextPageNumber");
         </p>
       </div>
       <div class="links-actions">
-        <a href={`/author/story/${story.id}`}>Back to story</a>
+        {isSteward && <span class="steward-flair">Steward mode</span>}
+        <a href={storyReturnHref}>{storyReturnLabel}</a>
         <a href="/author/links">Review all links</a>
       </div>
     </header>
 
-    <section class="links-section">
-      <h2>Existing links</h2>
-      {links.length ? (
-        <ul class="links-list" id="links-list">
-          {links.map((link) => (
-            <li class={`link-card link-card--${link.status}`}>
-              <div class="link-meta">
-                <span class="link-type">{link.linkType}</span>
-                <span class="link-status">{link.status}</span>
-              </div>
-              <div class="link-main">
-                <strong>{link.fromStory.title}</strong>
-                <span class="link-arrow">→</span>
-                <strong>{link.toStory.title}</strong>
-              </div>
-              {(link.toScene || link.toPageNumber) && (
-                <div class="link-target">
-                  {link.toScene && (
-                    <span>
-                      Scene {link.toScene.title ?? `#${link.toScene.id}`}
-                    </span>
-                  )}
-                  {link.toPageNumber && <span>Page {link.toPageNumber}</span>}
+    <div class="links-workspace">
+      <section class="links-section links-section--existing">
+        <h2>Existing links</h2>
+        {links.length ? (
+          <ul class="links-list" id="links-list">
+            {sortedLinks.map((link) => (
+              <li class={`link-card link-card--${link.status}`}>
+                <div class="link-meta">
+                  <span class="link-type">{link.linkType}</span>
+                  <span class="link-status">{link.status}</span>
                 </div>
-              )}
-              <p class="link-rationale">{link.rationale}</p>
-              <div class="link-actions">
-                <button
-                  type="button"
-                  class="link-action link-action--vote"
-                  data-link-id={link.id}
-                  data-vote="accept"
-                  disabled={link.status === "retired"}
-                >
-                  Accept
-                </button>
-                <button
-                  type="button"
-                  class="link-action link-action--vote"
-                  data-link-id={link.id}
-                  data-vote="reject"
-                  disabled={link.status === "retired"}
-                >
-                  Reject
-                </button>
-                {isSteward && (
-                  <button
-                    type="button"
-                    class="link-action link-action--retire"
-                    data-link-id={link.id}
-                    data-retire
-                  >
-                    {link.status === "retired" ? "Unretire" : "Retire"}
-                  </button>
+                <p class="link-date">
+                  Proposed {formatLinkDate(link.createdAt)} by {link.createdBy.name}
+                </p>
+                {linkDecisionDate(link) && (
+                  <p class="link-date">{linkDecisionDate(link)}</p>
                 )}
-              </div>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <div class="links-prompt">
-          <p>No links yet. Start by proposing a single interpretive link.</p>
-          <p class="links-prompt__hint">
-            Add a brief rationale explaining why the stories connect.
-          </p>
-        </div>
-      )}
-      {!isSteward && (
-        <p class="links-note">
-          Retire/unretire actions are visible to stewards only.
-        </p>
-      )}
-    </section>
-
-    <section class="links-section" id="propose">
-      <h2>Propose a new link</h2>
-      {(contextSceneId || contextPageNumber) && (
-        <div class="links-context">
-          <strong>Context</strong>
-          {contextSceneId && <span>Scene {contextSceneId}</span>}
-          {contextPageNumber && <span>Page {contextPageNumber}</span>}
-          <span class="links-context__hint">
-            This context is not saved; add it to your rationale if needed.
-          </span>
-        </div>
-      )}
-      <form id="link-form" class="link-form">
-        <label>
-          Target story
-          <select name="toStoryId" required>
-            <option value="">Select a story</option>
-            {otherStories.map((s) => (
-              <option value={s.id}>{s.title}</option>
+                <div class="link-main">
+                  <strong>{link.fromStory.title}</strong>
+                  <span class="link-arrow">→</span>
+                  <strong>{link.toStory.title}</strong>
+                </div>
+                {(link.toScene || link.toPageNumber) && (
+                  <div class="link-target">
+                    {link.toScene && (
+                      <span>
+                        Scene {link.toScene.title ?? `#${link.toScene.id}`}
+                      </span>
+                    )}
+                    {link.toPageNumber && <span>Page {link.toPageNumber}</span>}
+                  </div>
+                )}
+                <p class="link-rationale">{link.rationale}</p>
+                <div class="link-actions">
+                  {canVoteOnLinks && (
+                    <>
+                      <button
+                        type="button"
+                        class="link-action link-action--vote"
+                        data-link-id={link.id}
+                        data-vote="accept"
+                        disabled={link.status === "retired"}
+                      >
+                        Accept
+                      </button>
+                      <button
+                        type="button"
+                        class="link-action link-action--vote"
+                        data-link-id={link.id}
+                        data-vote="reject"
+                        disabled={link.status === "retired"}
+                      >
+                        Reject
+                      </button>
+                    </>
+                  )}
+                  {isSteward && (
+                    <button
+                      type="button"
+                      class="link-action link-action--retire"
+                      data-link-id={link.id}
+                      data-retire
+                    >
+                      {link.status === "retired" ? "Unretire" : "Retire"}
+                    </button>
+                  )}
+                </div>
+              </li>
             ))}
-          </select>
-        </label>
-        <label>
-          Link type
-          <select name="linkType" required>
-            <option value="adjacency">Adjacency</option>
-            <option value="thematic">Thematic</option>
-            <option value="causal">Causal</option>
-            <option value="contrast">Contrast</option>
-          </select>
-        </label>
-        <label>
-          Target scene id (optional)
-          <input type="number" name="toSceneId" min="1" />
-        </label>
-        <label>
-          Target page number (optional)
-          <input type="number" name="toPageNumber" min="1" />
-        </label>
-        <label>
-          Rationale
-          <textarea name="rationale" rows="4" required></textarea>
-        </label>
-        <button type="submit">Propose link</button>
-        <p class="link-form__status" id="link-form-status"></p>
-      </form>
-    </section>
+          </ul>
+        ) : (
+          <div class="links-prompt">
+            <p>No links yet. Start by proposing a single interpretive link.</p>
+            <p class="links-prompt__hint">
+              Add a brief rationale explaining why the stories connect.
+            </p>
+          </div>
+        )}
+        {!isSteward && (
+          <p class="links-note">
+            Retire/unretire actions are visible to stewards only.
+          </p>
+        )}
+        {!canVoteOnLinks && (
+          <p class="links-note">
+            Accept/reject voting is available to authors of linked stories and
+            stewards.
+          </p>
+        )}
+      </section>
+
+      <section class="links-section links-section--propose" id="propose">
+        <h2>Propose a new link</h2>
+        {(contextSceneId || contextPageNumber) && (
+          <div class="links-context">
+            <strong>Context</strong>
+            {contextSceneId && <span>Scene {contextSceneId}</span>}
+            {contextPageNumber && <span>Page {contextPageNumber}</span>}
+            <span class="links-context__hint">
+              This context is not saved; add it to your rationale if needed.
+            </span>
+          </div>
+        )}
+        <form id="link-form" class="link-form">
+          <label>
+            Target story
+            <select name="toStoryId" required>
+              <option value="">Select a story</option>
+              {otherStories.map((s) => (
+                <option
+                  value={s.id}
+                  selected={String(s.id) === prefillToStoryId}
+                >
+                  {s.title}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label>
+            Link type
+            <select name="linkType" required>
+              <option
+                value="adjacency"
+                selected={prefillLinkType === "adjacency"}
+              >
+                Adjacency
+              </option>
+              <option value="thematic" selected={prefillLinkType === "thematic"}>
+                Thematic
+              </option>
+              <option value="causal" selected={prefillLinkType === "causal"}>
+                Causal
+              </option>
+              <option value="contrast" selected={prefillLinkType === "contrast"}>
+                Contrast
+              </option>
+            </select>
+          </label>
+          <label>
+            Target scene id (optional)
+            <input
+              type="number"
+              name="toSceneId"
+              min="1"
+              value={prefillToSceneId ?? ""}
+            />
+          </label>
+          <label>
+            Target page number (optional)
+            <input
+              type="number"
+              name="toPageNumber"
+              min="1"
+              value={prefillToPageNumber ?? ""}
+            />
+          </label>
+          <label>
+            Rationale
+            <textarea name="rationale" rows="4" required></textarea>
+          </label>
+          <button type="submit">Propose link</button>
+          <p class="link-form__status" id="link-form-status"></p>
+        </form>
+      </section>
+    </div>
   </main>
 
   <script is:inline>
@@ -264,7 +355,7 @@ const contextPageNumber = Astro.url.searchParams.get("contextPageNumber");
 
 <style>
   .links-page {
-    max-width: 980px;
+    max-width: 1180px;
     margin: 2rem auto;
     padding: 0 1.5rem 3rem;
   }
@@ -297,8 +388,28 @@ const contextPageNumber = Astro.url.searchParams.get("contextPageNumber");
     color: inherit;
   }
 
+  .steward-flair {
+    border: 1px solid #5d387a;
+    border-radius: 999px;
+    padding: 0.35rem 0.75rem;
+    background: #f5ecff;
+    color: #4b2767;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-align: center;
+  }
+
   .links-section {
-    margin-top: 2rem;
+    min-width: 0;
+  }
+
+  .links-workspace {
+    display: grid;
+    gap: 2rem;
+  }
+
+  .links-section--propose {
+    align-self: start;
   }
 
   .links-list {
@@ -328,6 +439,12 @@ const contextPageNumber = Astro.url.searchParams.get("contextPageNumber");
     display: flex;
     gap: 0.5rem;
     align-items: center;
+  }
+
+  .link-date {
+    margin-top: 0.35rem;
+    font-size: 0.85rem;
+    opacity: 0.75;
   }
 
   .link-arrow {
@@ -412,7 +529,6 @@ const contextPageNumber = Astro.url.searchParams.get("contextPageNumber");
   .link-form {
     display: grid;
     gap: 1rem;
-    max-width: 520px;
   }
 
   .link-form textarea,
@@ -513,5 +629,33 @@ const contextPageNumber = Astro.url.searchParams.get("contextPageNumber");
   .link-form button[type="submit"]:focus-visible {
     outline: 2px solid #1f4d7a;
     outline-offset: 2px;
+  }
+
+  @media screen and (min-width: 960px) {
+    .links-workspace {
+      grid-template-columns: minmax(0, 1fr) minmax(320px, 360px);
+      align-items: start;
+    }
+
+    .links-section--propose {
+      position: sticky;
+      top: 1rem;
+    }
+  }
+
+  @media screen and (max-width: 720px) {
+    .links-header {
+      flex-direction: column;
+    }
+
+    .links-actions {
+      flex-direction: row;
+      flex-wrap: wrap;
+    }
+
+    .link-main,
+    .link-actions {
+      flex-wrap: wrap;
+    }
   }
 </style>

--- a/src/pages/login/callback.astro
+++ b/src/pages/login/callback.astro
@@ -1,6 +1,7 @@
 ---
 import { Icon } from "astro-icon/components";
 
+import { safeReturnTo } from "../../authentication/returnTo";
 import Layout from "../../layouts/AuthoringLayout.astro";
 
 import "./_login.module.css";
@@ -8,20 +9,22 @@ import "./_login.module.css";
 const { magic, i18n } = Astro.locals.environment<
   App.WithMagicAuthenticationConfig & App.WithI18N
 >();
+const returnTo = safeReturnTo(Astro.url.searchParams.get("returnTo"));
 ---
 
 <script>
+  import { safeReturnTo } from "../../authentication/returnTo.js";
   import authenticateWithServerUsingCredential from "../../authentication/client/authenticateWithServerUsingCredential.js";
 
   const magicPublicKey =
     document.getElementById("callback")!.dataset["magicPublicKey"]!;
+  const returnTo = safeReturnTo(
+    document.getElementById("callback")!.dataset["returnTo"],
+  );
 
   authenticateWithServerUsingCredential(magicPublicKey)
     .then(() => {
-      window.location.href = new URL(
-        `author/story`,
-        window.location.origin,
-      ).href;
+      window.location.href = new URL(returnTo, window.location.origin).href;
     })
     .catch(() => {
       window.location.href = new URL(
@@ -35,7 +38,11 @@ const { magic, i18n } = Astro.locals.environment<
   title={i18n.t("page.login-callback.meta.title")}
   description={i18n.t("page.login-callback.meta.description")}
 >
-  <main id="callback" data-magic-public-key={magic.publicKey}>
+  <main
+    id="callback"
+    data-magic-public-key={magic.publicKey}
+    data-return-to={returnTo}
+  >
     <Icon name="noto-v1:love-letter" size="medium" />
     <div>{i18n.t("page.login-callback.message")}</div>
     <img

--- a/src/pages/login/index.astro
+++ b/src/pages/login/index.astro
@@ -1,4 +1,5 @@
 ---
+import { safeReturnTo } from "../../authentication/returnTo";
 import Login from "../../components/authentication/Login";
 import LoginInProgress from "../../components/authentication/LoginInProgress.astro";
 import Layout from "../../layouts/AuthoringLayout.astro";
@@ -13,6 +14,7 @@ const translations = i18n.getTranslationsForPage({
   locale: Astro.preferredLocale,
   page: "login",
 });
+const returnTo = safeReturnTo(Astro.url.searchParams.get("returnTo"));
 ---
 
 <Layout
@@ -22,6 +24,7 @@ const translations = i18n.getTranslationsForPage({
   <main>
     <Login
       magicPublicKey={magic.publicKey}
+      returnTo={returnTo}
       translations={translations}
       client:only="react"
     >

--- a/src/pages/story/[storyId]/index.astro
+++ b/src/pages/story/[storyId]/index.astro
@@ -22,66 +22,20 @@ if (!story) {
 
 const links = await repositoryStoryLink.getStoryLinksForStory(storyId);
 const acceptedLinks = links.filter((link) => link.status === "accepted");
-const inboundLinks = acceptedLinks.filter((link) => link.toStory.id === storyId);
-const outboundLinks = acceptedLinks.filter((link) => link.fromStory.id === storyId);
+const retiredLinks = links.filter((link) => link.status === "retired");
+const inboundLinks = acceptedLinks.filter(
+  (link) => link.toStory.id === storyId,
+);
+const outboundLinks = acceptedLinks.filter(
+  (link) => link.fromStory.id === storyId,
+);
 
 const linkedStories = new Map<number, { id: number; title: string }>();
 acceptedLinks.forEach((link) => {
-  const other =
-    link.fromStory.id === storyId ? link.toStory : link.fromStory;
+  const other = link.fromStory.id === storyId ? link.toStory : link.fromStory;
   linkedStories.set(other.id, { id: other.id, title: other.title });
 });
 const linkedStoryCards = Array.from(linkedStories.values()).slice(0, 5);
-
-type ContextLink = {
-  fromStoryId: number;
-  fromStoryTitle: string;
-  linkType: string;
-  rationale: string;
-  toSceneId: number;
-  toSceneTitle: string | null;
-  toPageNumber: number | null;
-};
-
-const contextByScene = new Map<number, ContextLink[]>();
-const contextByPage = new Map<string, ContextLink[]>();
-
-acceptedLinks
-  .filter((link) => link.toStory.id === storyId && link.toScene)
-  .forEach((link) => {
-    const contextLink: ContextLink = {
-      fromStoryId: link.fromStory.id,
-      fromStoryTitle: link.fromStory.title,
-      linkType: link.linkType,
-      rationale: link.rationale,
-      toSceneId: link.toScene!.id,
-      toSceneTitle: link.toScene?.title ?? null,
-      toPageNumber: link.toPageNumber ?? null,
-    };
-
-    const sceneLinks = contextByScene.get(contextLink.toSceneId) ?? [];
-    sceneLinks.push(contextLink);
-    contextByScene.set(contextLink.toSceneId, sceneLinks);
-
-    if (contextLink.toPageNumber !== null) {
-      const pageKey = `${contextLink.toSceneId}:${contextLink.toPageNumber}`;
-      const pageLinks = contextByPage.get(pageKey) ?? [];
-      pageLinks.push(contextLink);
-      contextByPage.set(pageKey, pageLinks);
-    }
-  });
-
-const contextData = {
-  byScene: Object.fromEntries(contextByScene.entries()),
-  byPage: Object.fromEntries(contextByPage.entries()),
-};
-
-const serializedContext = JSON.stringify(contextData)
-  .replace(/</g, "\\u003C")
-  .replace(/>/g, "\\u003E")
-  .replace(/&/g, "\\u0026")
-  .replace(/\u2028/g, "\\u2028")
-  .replace(/\u2029/g, "\\u2029");
 ---
 
 <!doctype html>
@@ -107,8 +61,6 @@ const serializedContext = JSON.stringify(contextData)
     Interpretive
   </button>
 
-  <script set:html={`window.vsatInterpretiveContext = ${serializedContext}`} />
-
   <aside class="interpretive-drawer" aria-hidden="true" hidden>
     <details>
       <summary>
@@ -118,16 +70,6 @@ const serializedContext = JSON.stringify(contextData)
         </span>
       </summary>
       <div class="interpretive-body">
-        <section class="interpretive-context-panel" data-interpretive-context>
-          <h2>Current scene/page</h2>
-          <p class="context-label" data-interpretive-label>
-            Scene · Page
-          </p>
-          <ul class="context-links" data-interpretive-links></ul>
-          <p class="empty" data-interpretive-empty>
-            No interpretive links for this scene/page yet.
-          </p>
-        </section>
         {acceptedLinks.length ? (
           <>
             <section>
@@ -189,12 +131,38 @@ const serializedContext = JSON.stringify(contextData)
           </>
         ) : (
           <p class="empty">
-            No accepted interpretive links yet. Try VSATLATARIUM to propose one.
+            No accepted interpretive links yet.
           </p>
         )}
+        <a
+          class="interpretive-cta"
+          href={`/author/story/${story.id}/links?returnTo=${encodeURIComponent(`/story/${story.id}`)}#propose`}
+        >
+          Propose an interpretive link
+        </a>
         <a class="interpretive-cta" href="/story/vsatlatarium">
           Open VSATLATARIUM
         </a>
+        {retiredLinks.length > 0 && (
+          <section>
+            <h2>Stewardship history</h2>
+            <ul>
+              {retiredLinks.map((link) => {
+                const other =
+                  link.fromStory.id === storyId ? link.toStory : link.fromStory;
+                return (
+                  <li>
+                    <a href={`/story/${other.id}`}>{other.title}</a>
+                    <span class="link-meta">
+                      {link.linkType} · retired
+                    </span>
+                    <p class="link-rationale">{link.rationale}</p>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
       </div>
     </details>
   </aside>
@@ -260,69 +228,6 @@ const serializedContext = JSON.stringify(contextData)
       peekOpen = false;
       syncOverlay();
     }
-  });
-
-  const contextData =
-    window.vsatInterpretiveContext || Object.freeze({ byScene: {}, byPage: {} });
-
-  const contextPanels = Array.from(
-    document.querySelectorAll("[data-interpretive-context]"),
-  );
-
-  const renderContextLinks = (links, sceneTitle, pageNumber) => {
-    contextPanels.forEach((panel) => {
-      const label = panel.querySelector("[data-interpretive-label]");
-      const list = panel.querySelector("[data-interpretive-links]");
-      const empty = panel.querySelector("[data-interpretive-empty]");
-
-      if (label) {
-        const title = sceneTitle || "Scene";
-        label.textContent = `${title} · Page ${pageNumber ?? "?"}`;
-      }
-
-      if (list) {
-        list.innerHTML = "";
-        links.forEach((link) => {
-          const item = document.createElement("li");
-          const anchor = document.createElement("a");
-          anchor.href = `/story/${link.fromStoryId}`;
-          anchor.textContent = link.fromStoryTitle;
-
-          const meta = document.createElement("span");
-          meta.className = "link-meta";
-          meta.textContent = `${link.linkType} · ${link.scope} link`;
-
-          const rationale = document.createElement("p");
-          rationale.className = "link-rationale";
-          rationale.textContent = link.rationale;
-
-          item.append(anchor, meta, rationale);
-          list.append(item);
-        });
-      }
-
-      if (empty) {
-        empty.hidden = links.length > 0;
-      }
-    });
-  };
-
-  const syncContext = (detail) => {
-    if (!detail?.sceneId) {
-      return;
-    }
-    const pageKey = `${detail.sceneId}:${detail.pageNumber ?? ""}`;
-    const pageLinks = contextData.byPage?.[pageKey] ?? [];
-    const sceneLinks = contextData.byScene?.[detail.sceneId] ?? [];
-    const scopedLinks = pageLinks.length
-      ? pageLinks.map((link) => ({ ...link, scope: "page" }))
-      : sceneLinks.map((link) => ({ ...link, scope: "scene" }));
-
-    renderContextLinks(scopedLinks, detail.sceneTitle, detail.pageNumber);
-  };
-
-  window.addEventListener("vsat:story-context", (event) => {
-    syncContext(event.detail);
   });
 
   syncOverlay();
@@ -465,27 +370,6 @@ const serializedContext = JSON.stringify(contextData)
     text-decoration: none;
     color: inherit;
     background: #fff;
-  }
-
-  .interpretive-context-panel {
-    border: 1px dashed #1f4d7a;
-    border-radius: 0.75rem;
-    padding: 0.75rem 0.9rem;
-    background: rgba(231, 242, 255, 0.7);
-    display: grid;
-    gap: 0.5rem;
-  }
-
-  .context-label {
-    font-weight: 600;
-  }
-
-  .context-links {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: grid;
-    gap: 0.5rem;
   }
 
   @media screen and (max-width: 720px) {

--- a/tests/unit/authentication/returnTo.test.ts
+++ b/tests/unit/authentication/returnTo.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  loginPathForReturnTo,
+  safeReturnTo,
+} from "@authentication/returnTo.js";
+
+describe("safeReturnTo", () => {
+  test("given a relative path returns the path", () => {
+    assert.equal(
+      safeReturnTo("/author/story/12/links#propose"),
+      "/author/story/12/links#propose",
+    );
+  });
+
+  test("given an encoded relative path returns the decoded path", () => {
+    assert.equal(
+      safeReturnTo("%2Fauthor%2Fstory%2F12%2Flinks%3FtoStoryId%3D14%23propose"),
+      "/author/story/12/links?toStoryId=14#propose",
+    );
+  });
+
+  test("given a blank value returns the default author dashboard path", () => {
+    assert.equal(safeReturnTo(null), "/author/story");
+  });
+
+  test("given an absolute URL returns the default author dashboard path", () => {
+    assert.equal(safeReturnTo("https://example.com/steal"), "/author/story");
+  });
+
+  test("given a protocol-relative URL returns the default author dashboard path", () => {
+    assert.equal(safeReturnTo("//example.com/steal"), "/author/story");
+  });
+
+  test("given malformed URI encoding returns the default author dashboard path", () => {
+    assert.equal(safeReturnTo("%"), "/author/story");
+  });
+});
+
+describe("loginPathForReturnTo", () => {
+  test("encodes the safe return path into the login URL", () => {
+    assert.equal(
+      loginPathForReturnTo("/author/story/12/links?toStoryId=14#propose"),
+      "/login?returnTo=%2Fauthor%2Fstory%2F12%2Flinks%3FtoStoryId%3D14%23propose",
+    );
+  });
+});


### PR DESCRIPTION
- **returnTo** — carry the intended destination through magic-link login (`returnTo.ts`, login pages, `Login.tsx`, `authenticationRequired`).
- **Interpretive links** — vote eligibility (`canVoteOnStoryLinkInDatabase`) and retirement, summary mapping, `routeStoryLinks` wiring, author/steward page + story drawer updates.
- **Docs/tests** — `role-sitemap` + `qa-checklist` updates, returnTo unit tests.

## Testing
- Server typechecks.
- returnTo unit tests pass.
