### PR TITLE
Add phone/laptop remote control for live story sessions

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -53,6 +53,10 @@ export default defineConfig({
       },
       proxy: {
         "/api": `http://localhost:${devApiPort}`,
+        "/ws": {
+          target: `ws://localhost:${devApiPort}`,
+          ws: true,
+        },
       },
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@fontsource/source-sans-pro": "^5.2.5",
         "@magic-sdk/admin": "^2.8.0",
         "@tanstack/react-query": "^5.90.20",
+        "@types/qrcode": "^1.5.6",
+        "@types/ws": "^8.18.1",
         "astro": "^5.17.1",
         "astro-icon": "^1.1.5",
         "cloudinary": "^2.9.0",
@@ -33,6 +35,7 @@
         "passport-magic": "^1.0.0",
         "pg": "^8.18.0",
         "pino": "^10.3.0",
+        "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-error-boundary": "^4.1.2",
@@ -43,6 +46,7 @@
         "slate-history": "^0.113.1",
         "slate-react": "^0.118.2",
         "sweetalert2": "^11.26.18",
+        "ws": "^8.21.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -3177,6 +3181,15 @@
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
       "license": "MIT"
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/qs": {
       "version": "6.9.17",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.17.tgz",
@@ -3320,6 +3333,15 @@
       "integrity": "sha512-JGpU6qiIJQKUuVSKx1GtQnHJGxRjtfGIhzO2ilq43VZZS//f1h1Sgexbdk+Lq+7569a6EYhOWrUpIruR/1Enmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -6062,6 +6084,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
@@ -6186,6 +6217,12 @@
       "engines": {
         "node": ">=0.3.1"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/direction": {
       "version": "1.0.4",
@@ -6783,6 +6820,27 @@
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "license": "0BSD"
     },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ethjs-util": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
@@ -7101,6 +7159,19 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/flattie": {
@@ -8289,27 +8360,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/jsdom/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -8464,6 +8514,18 @@
       "license": "Apache-2.0",
       "dependencies": {
         "lie": "3.1.1"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lodash": {
@@ -9894,6 +9956,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-queue": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.1.tgz",
@@ -9920,6 +10009,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/package-json-from-dist": {
@@ -10437,6 +10535,15 @@
       "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "license": "MIT"
     },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -10754,6 +10861,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11015,6 +11131,154 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/qrcode/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/qrcode/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -11491,6 +11755,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -11872,6 +12142,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
       "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "license": "ISC"
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
     },
     "node_modules/set-function-length": {
@@ -14080,6 +14356,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
@@ -14229,9 +14511,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
-      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "@fontsource/source-sans-pro": "^5.2.5",
     "@magic-sdk/admin": "^2.8.0",
     "@tanstack/react-query": "^5.90.20",
+    "@types/qrcode": "^1.5.6",
+    "@types/ws": "^8.18.1",
     "astro": "^5.17.1",
     "astro-icon": "^1.1.5",
     "cloudinary": "^2.9.0",
@@ -69,6 +71,7 @@
     "passport-magic": "^1.0.0",
     "pg": "^8.18.0",
     "pino": "^10.3.0",
+    "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-error-boundary": "^4.1.2",
@@ -79,6 +82,7 @@
     "slate-history": "^0.113.1",
     "slate-react": "^0.118.2",
     "sweetalert2": "^11.26.18",
+    "ws": "^8.21.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/components/story/remote/hostController.ts
+++ b/src/components/story/remote/hostController.ts
@@ -1,7 +1,10 @@
 import {
   isHeadingBlock,
   isLinkBlock,
+  isPlaintextBlock,
 } from "@domain/story/publish/support/isBlock";
+import openingPageFor from "@domain/story/publish/support/openingPage";
+import openingSceneFor from "@domain/story/publish/support/openingScene";
 import { isTitleCardScene } from "../published/aframe/titleCardSceneFor";
 import type { Current } from "../published/aframe/types";
 
@@ -27,6 +30,10 @@ type StateMessage = {
   sceneTitle: string;
   /** The current page's `# Heading` — the big text the reader sees on screen. */
   heading: string;
+  /** The page's fiction body (plaintext paragraphs), for the headset window. */
+  body: string;
+  /** URL of the current scene's 360° photosphere, or null for a title card with none. */
+  image: string | null;
   pageNumber: number;
   links: LinkOption[];
 };
@@ -116,12 +123,21 @@ export function startHostController(): void {
     // it's the most recognisable "where am I now" label for the remote.
     const heading = current.page.content.find(isHeadingBlock)?.text ?? "";
 
+    // The fiction body + photosphere let the remote render a "headset window".
+    const body = current.page.content
+      .filter(isPlaintextBlock)
+      .map((block) => block.text)
+      .join("\n\n");
+    const image = current.scene?.image?.url ?? null;
+
     return {
       type: "state",
       storyTitle: current.story?.title ?? "",
       sceneId: current.scene?.id,
       sceneTitle,
       heading,
+      body,
+      image,
       pageNumber: current.page.number,
       links,
     };
@@ -165,6 +181,32 @@ export function startHostController(): void {
           new CustomEvent("linkactivated", { detail: message.link }),
         );
       }
+      return;
+    }
+
+    if (message.type === "restart") {
+      // Pull the experience back to the story's opening scene/page (e.g. to
+      // recover a headset user from a dead end). Re-render directly rather than
+      // via a link so it works from any page, including ones with no exits.
+      const current = (window as unknown as { current?: Current }).current;
+      const storyEl = document.querySelector("[story]") as
+        | (Element & {
+            components?: {
+              story?: {
+                render?: (c: Current, o: { isSceneChange: boolean }) => void;
+              };
+            };
+          })
+        | null;
+      const story = current?.story;
+      const render = storyEl?.components?.story?.render;
+      if (!story || !render) {
+        return;
+      }
+      const openingScene = openingSceneFor(story);
+      current.scene = openingScene;
+      current.page = openingPageFor(openingScene);
+      render.call(storyEl.components?.story, current, { isSceneChange: true });
     }
   };
 

--- a/src/components/story/remote/hostController.ts
+++ b/src/components/story/remote/hostController.ts
@@ -1,0 +1,188 @@
+import {
+  isHeadingBlock,
+  isLinkBlock,
+} from "@domain/story/publish/support/isBlock";
+import { isTitleCardScene } from "../published/aframe/titleCardSceneFor";
+import type { Current } from "../published/aframe/types";
+
+/**
+ * The "host" side of the remote-control feature.
+ *
+ * Runs inside the story viewer (the screen being driven — headset second
+ * monitor, SimLab projection, etc.). Activates only when the page URL carries a
+ * `?room=<code>`; otherwise it does nothing, so normal viewing is unaffected.
+ *
+ * Responsibilities:
+ *  - publish the current scene + its available links to the room (the phone's
+ *    "monitor" view), and
+ *  - apply `navigate` commands coming back from the phone by re-emitting the
+ *    same `linkactivated` event a click would have produced.
+ */
+type LinkOption = { text: string; link: string };
+
+type StateMessage = {
+  type: "state";
+  storyTitle: string;
+  sceneId: number | undefined;
+  sceneTitle: string;
+  /** The current page's `# Heading` — the big text the reader sees on screen. */
+  heading: string;
+  pageNumber: number;
+  links: LinkOption[];
+};
+
+/**
+ * Codes a person may have to read aloud (e.g. from inside a headset), so the
+ * alphabet drops easily-confused characters (no 0/O, 1/I/L).
+ */
+const CODE_ALPHABET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+
+function generateCode(length = 4): string {
+  const buffer = new Uint32Array(length);
+  window.crypto?.getRandomValues?.(buffer);
+  let code = "";
+  for (let i = 0; i < length; i += 1) {
+    const value = buffer[i] || Math.floor(Math.random() * CODE_ALPHABET.length);
+    code += CODE_ALPHABET[value % CODE_ALPHABET.length];
+  }
+  return code;
+}
+
+function showBadge(code: string): void {
+  const badge = document.createElement("div");
+  badge.textContent = `Remote: ${code}`;
+  badge.style.cssText = [
+    "position:fixed",
+    "top:0.6rem",
+    "right:0.6rem",
+    "z-index:10002",
+    "padding:0.35rem 0.6rem",
+    "border-radius:999px",
+    "background:rgba(20,23,28,0.85)",
+    "color:#ecf0f1",
+    "font:600 0.8rem/1 'Source Sans Pro',system-ui,sans-serif",
+    "letter-spacing:0.08em",
+    "pointer-events:none",
+  ].join(";");
+  document.body.appendChild(badge);
+}
+
+export function startHostController(): void {
+  const params = new URLSearchParams(window.location.search);
+
+  // Arming is opt-in: only when the URL carries a `room` param. An empty value
+  // (`?room` / `?room=`) means "start a session" — generate a code and pin it
+  // into the URL so it can be shared or reloaded.
+  if (!params.has("room")) {
+    return;
+  }
+
+  let room = params.get("room")?.trim() ?? "";
+  if (!room) {
+    room = generateCode();
+    params.set("room", room);
+    const query = params.toString();
+    window.history.replaceState(
+      null,
+      "",
+      `${window.location.pathname}?${query}${window.location.hash}`,
+    );
+  }
+
+  showBadge(room);
+
+  const protocol = window.location.protocol === "https:" ? "wss" : "ws";
+  const url = `${protocol}://${window.location.host}/ws/relay?room=${encodeURIComponent(room)}&role=host`;
+  let socket: WebSocket | null = null;
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const collectState = (): StateMessage | null => {
+    const current = (window as unknown as { current?: Current }).current;
+    if (!current?.page) {
+      return null;
+    }
+
+    const links: LinkOption[] = current.page.content
+      .filter(isLinkBlock)
+      .map((block) => ({ text: block.text, link: block.link }));
+
+    // The title card is a synthetic scene whose title is an internal sentinel;
+    // show the story title there instead.
+    const sceneTitle = isTitleCardScene(current.scene)
+      ? (current.story?.title ?? "")
+      : (current.scene?.title ?? "");
+
+    // The page heading is what the reader actually reads on the 3D screen, so
+    // it's the most recognisable "where am I now" label for the remote.
+    const heading = current.page.content.find(isHeadingBlock)?.text ?? "";
+
+    return {
+      type: "state",
+      storyTitle: current.story?.title ?? "",
+      sceneId: current.scene?.id,
+      sceneTitle,
+      heading,
+      pageNumber: current.page.number,
+      links,
+    };
+  };
+
+  const sendState = () => {
+    if (socket?.readyState !== WebSocket.OPEN) {
+      return;
+    }
+    const state = collectState();
+    if (state) {
+      socket.send(JSON.stringify(state));
+    }
+  };
+
+  const handleMessage = (event: MessageEvent) => {
+    let message: { type?: string; link?: unknown };
+    try {
+      message = JSON.parse(event.data as string);
+    } catch {
+      return;
+    }
+
+    if (message.type === "hello") {
+      // A phone just connected and wants the current state.
+      sendState();
+      return;
+    }
+
+    if (message.type === "navigate" && typeof message.link === "string") {
+      const storyEl = document.querySelector("[story]") as
+        | (Element & { emit?: (name: string, detail: unknown) => void })
+        | null;
+      if (!storyEl) {
+        return;
+      }
+      if (typeof storyEl.emit === "function") {
+        storyEl.emit("linkactivated", message.link);
+      } else {
+        storyEl.dispatchEvent(
+          new CustomEvent("linkactivated", { detail: message.link }),
+        );
+      }
+    }
+  };
+
+  // Reconnect if the socket drops (e.g. Heroku dyno cycling, network blip) so
+  // the experience stays drivable without a page reload.
+  const connect = () => {
+    socket = new WebSocket(url);
+    socket.addEventListener("open", sendState);
+    socket.addEventListener("message", handleMessage);
+    socket.addEventListener("close", () => {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = setTimeout(connect, 1000);
+    });
+    socket.addEventListener("error", () => socket?.close());
+  };
+
+  // The story view dispatches this every time it (re)renders a page.
+  window.addEventListener("vsat:story-context", sendState);
+
+  connect();
+}

--- a/src/createApp.ts
+++ b/src/createApp.ts
@@ -32,6 +32,7 @@ import isAuthorOfTheStory from "./domain/story/support/isAuthorOfTheStory.js";
 import loadConfig from "./environment/config.js";
 import getEnvironment from "./environment/getEnvironment.js";
 import type { StartServer } from "./server/createServer.js";
+import routeSessions from "./server/relay/routeSessions.js";
 import httpSession from "./server/httpSessionMiddleware.js";
 import routeHealthcheck from "./server/routeHealthcheck.js";
 import { withHeadersToEnableSharedArrayBufferUsage } from "./server/staticHeadersMiddleware.js";
@@ -213,6 +214,7 @@ export async function createAppParts(): Promise<{
       assertIsAuthorOfTheStory,
     ),
     routeGetPublishedStories(log, repositoryStory.getPublishedStorySummaries),
+    routeSessions(),
   ].reduce((router, route) => {
     router.use("/api", route);
     return router;

--- a/src/pages/remote/index.astro
+++ b/src/pages/remote/index.astro
@@ -1,0 +1,483 @@
+---
+// The phone/laptop "remote" view.
+//   /remote            → lobby: a grid of live sessions (tap to co-pilot in
+//                        place, or scan a tile's QR with a phone to join there)
+//   /remote?room=CODE  → control surface for one session
+// Dependency-light and works on both phone and laptop.
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <title>VSAT Remote</title>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>VSAT Remote</h1>
+        <p class="status" data-status hidden></p>
+      </header>
+
+      <!-- Lobby -->
+      <section class="lobby" data-lobby hidden>
+        <p class="lobby-intro">
+          Active sessions — tap to co-pilot, or scan a tile with a phone.
+        </p>
+        <div class="tiles" data-tiles></div>
+        <p class="empty" data-lobby-empty hidden>
+          No active sessions. Open a story with <code>?room</code> to start one.
+        </p>
+        <p class="empty" data-lobby-restricted hidden>
+          The session lobby is for stewards. If someone gave you a code, join below.
+        </p>
+        <form class="manual" data-manual>
+          <input
+            name="room"
+            autocapitalize="characters"
+            autocomplete="off"
+            placeholder="Join by code"
+            required
+          />
+          <button type="submit">Join</button>
+        </form>
+      </section>
+
+      <!-- Control surface -->
+      <section class="control" data-control hidden>
+        <a class="back" href="/remote">← Sessions</a>
+
+        <section class="now" data-now hidden>
+          <p class="now-story" data-story></p>
+          <h2 class="now-scene" data-scene></h2>
+          <p class="now-page" data-context></p>
+        </section>
+
+        <section class="links" data-links hidden>
+          <p class="links-label">Go to</p>
+          <div class="links-list" data-links-list></div>
+        </section>
+
+        <p class="empty" data-empty hidden>No exits from this page.</p>
+      </section>
+    </main>
+
+    <script>
+      import QRCode from "qrcode";
+
+      const el = {
+        status: document.querySelector("[data-status]"),
+        lobby: document.querySelector("[data-lobby]"),
+        tiles: document.querySelector("[data-tiles]"),
+        lobbyEmpty: document.querySelector("[data-lobby-empty]"),
+        lobbyRestricted: document.querySelector("[data-lobby-restricted]"),
+        manual: document.querySelector("[data-manual]"),
+        control: document.querySelector("[data-control]"),
+        now: document.querySelector("[data-now]"),
+        story: document.querySelector("[data-story]"),
+        scene: document.querySelector("[data-scene]"),
+        context: document.querySelector("[data-context]"),
+        links: document.querySelector("[data-links]"),
+        linksList: document.querySelector("[data-links-list]"),
+        empty: document.querySelector("[data-empty]"),
+      };
+
+      const room = new URLSearchParams(location.search).get("room");
+
+      if (room) {
+        startControl(room);
+      } else {
+        startLobby();
+      }
+
+      // ----- Lobby -------------------------------------------------------------
+
+      function startLobby() {
+        el.lobby.hidden = false;
+
+        el.manual.addEventListener("submit", (event) => {
+          event.preventDefault();
+          const value = new FormData(el.manual)
+            .get("room")
+            ?.toString()
+            .trim()
+            .toUpperCase();
+          if (value) {
+            location.search = `?room=${encodeURIComponent(value)}`;
+          }
+        });
+
+        const tiles = new Map(); // code -> { el, story, scene }
+        let timer;
+
+        const refresh = async () => {
+          let sessions = [];
+          try {
+            const res = await fetch("/api/sessions", {
+              headers: { accept: "application/json" },
+            });
+            if (res.status === 403) {
+              // Discovery is steward-only; stop polling and explain.
+              clearInterval(timer);
+              el.lobbyRestricted.hidden = false;
+              el.lobbyEmpty.hidden = true;
+              return;
+            }
+            if (res.ok) {
+              sessions = (await res.json()).sessions ?? [];
+            }
+          } catch {
+            return;
+          }
+
+          const seen = new Set();
+          for (const session of sessions) {
+            seen.add(session.code);
+            const existing = tiles.get(session.code);
+            if (existing) {
+              existing.story.textContent = session.storyTitle || "Untitled story";
+              existing.scene.textContent =
+                session.heading || session.sceneTitle || "";
+            } else {
+              tiles.set(session.code, makeTile(session));
+            }
+          }
+
+          // Drop tiles for sessions that have ended.
+          for (const [code, tile] of tiles) {
+            if (!seen.has(code)) {
+              tile.el.remove();
+              tiles.delete(code);
+            }
+          }
+
+          el.lobbyEmpty.hidden = tiles.size > 0;
+        };
+
+        refresh();
+        timer = setInterval(refresh, 2000);
+      }
+
+      function makeTile(session) {
+        const anchor = document.createElement("a");
+        anchor.className = "tile";
+        anchor.href = `/remote?room=${encodeURIComponent(session.code)}`;
+
+        const info = document.createElement("div");
+        info.className = "tile-info";
+
+        const story = document.createElement("p");
+        story.className = "tile-story";
+        story.textContent = session.storyTitle || "Untitled story";
+
+        const scene = document.createElement("p");
+        scene.className = "tile-scene";
+        scene.textContent = session.heading || session.sceneTitle || "";
+
+        const code = document.createElement("p");
+        code.className = "tile-code";
+        code.textContent = session.code;
+
+        info.append(story, scene, code);
+
+        const canvas = document.createElement("canvas");
+        canvas.className = "tile-qr";
+        const joinUrl = `${location.origin}/remote?room=${encodeURIComponent(session.code)}`;
+        QRCode.toCanvas(canvas, joinUrl, {
+          width: 96,
+          margin: 1,
+          color: { dark: "#15171c", light: "#ffffff" },
+        }).catch(() => {});
+
+        anchor.append(info, canvas);
+        el.tiles.appendChild(anchor);
+
+        return { el: anchor, story, scene };
+      }
+
+      // ----- Control surface ---------------------------------------------------
+
+      function setStatus(text, kind) {
+        el.status.hidden = false;
+        el.status.textContent = text;
+        el.status.dataset.kind = kind || "";
+      }
+
+      function startControl(room) {
+        el.control.hidden = false;
+        setStatus("Connecting…", "");
+
+        const protocol = location.protocol === "https:" ? "wss" : "ws";
+        const url = `${protocol}://${location.host}/ws/relay?room=${encodeURIComponent(room)}&role=remote`;
+        let socket;
+        let reconnectTimer;
+
+        const open = () => {
+          socket = new WebSocket(url);
+
+          socket.addEventListener("open", () => {
+            setStatus(`Paired · room ${room}`, "ok");
+            socket.send(JSON.stringify({ type: "hello" }));
+          });
+
+          socket.addEventListener("message", (event) => {
+            let message;
+            try {
+              message = JSON.parse(event.data);
+            } catch {
+              return;
+            }
+            if (message.type === "state") {
+              render(message, socket);
+            }
+          });
+
+          socket.addEventListener("close", () => {
+            setStatus("Reconnecting…", "warn");
+            clearTimeout(reconnectTimer);
+            reconnectTimer = setTimeout(open, 1000);
+          });
+
+          socket.addEventListener("error", () => socket.close());
+        };
+
+        open();
+      }
+
+      function render(state, socket) {
+        el.now.hidden = false;
+        el.story.textContent = state.storyTitle || "";
+
+        // Lead with the page heading the reader actually sees on screen; fall
+        // back to the scene title if a page has no heading.
+        const heading = state.heading || state.sceneTitle || "Untitled";
+        el.scene.textContent = heading;
+
+        // Context line: scene title (when it differs from the heading) + page.
+        const parts = [];
+        if (state.sceneTitle && state.sceneTitle !== heading) {
+          parts.push(state.sceneTitle);
+        }
+        if (typeof state.pageNumber === "number") {
+          parts.push(`Page ${state.pageNumber + 1}`);
+        }
+        el.context.textContent = parts.join(" · ");
+
+        el.linksList.replaceChildren();
+        const links = Array.isArray(state.links) ? state.links : [];
+
+        if (links.length === 0) {
+          el.links.hidden = true;
+          el.empty.hidden = false;
+          return;
+        }
+
+        el.empty.hidden = true;
+        el.links.hidden = false;
+
+        for (const option of links) {
+          const button = document.createElement("button");
+          button.type = "button";
+          button.className = "link-button";
+          button.textContent = option.text || option.link;
+          button.addEventListener("click", () => {
+            socket.send(
+              JSON.stringify({ type: "navigate", link: option.link }),
+            );
+          });
+          el.linksList.appendChild(button);
+        }
+      }
+    </script>
+
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: "Source Sans Pro", system-ui, sans-serif;
+        background: #15171c;
+        color: #ecf0f1;
+        min-height: 100vh;
+      }
+      main {
+        max-width: 32rem;
+        margin: 0 auto;
+        padding: 1.25rem 1.1rem calc(1.5rem + env(safe-area-inset-bottom));
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 1.1rem;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        opacity: 0.85;
+      }
+      .status {
+        margin: 0.35rem 0 0;
+        font-size: 0.85rem;
+        opacity: 0.7;
+      }
+      .status[data-kind="ok"] {
+        color: #4ade80;
+        opacity: 1;
+      }
+      .status[data-kind="warn"] {
+        color: #fbbf24;
+        opacity: 1;
+      }
+
+      /* Lobby */
+      .lobby-intro {
+        margin: 0;
+        font-size: 0.9rem;
+        opacity: 0.7;
+      }
+      .tiles {
+        display: grid;
+        gap: 0.75rem;
+      }
+      .tile {
+        display: flex;
+        gap: 0.9rem;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.9rem 1rem;
+        border: 1px solid #2c3340;
+        border-radius: 0.9rem;
+        background: #1b1e25;
+        color: inherit;
+        text-decoration: none;
+        transition: border-color 0.12s ease, background 0.12s ease;
+      }
+      .tile:active {
+        background: #222631;
+        border-color: #3c5976;
+      }
+      .tile-info {
+        min-width: 0;
+      }
+      .tile-story {
+        margin: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+      }
+      .tile-scene {
+        margin: 0.2rem 0 0;
+        font-size: 0.85rem;
+        opacity: 0.7;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .tile-code {
+        margin: 0.4rem 0 0;
+        font-size: 0.78rem;
+        letter-spacing: 0.18em;
+        opacity: 0.5;
+      }
+      .tile-qr {
+        flex: none;
+        width: 72px;
+        height: 72px;
+        border-radius: 0.4rem;
+        background: #fff;
+      }
+      .manual {
+        display: flex;
+        gap: 0.5rem;
+      }
+      .manual input {
+        flex: 1;
+        padding: 0.7rem;
+        border-radius: 0.6rem;
+        border: 1px solid #3c4250;
+        background: #1f232b;
+        color: inherit;
+        font-size: 1rem;
+        text-transform: uppercase;
+      }
+      .manual button {
+        padding: 0.7rem 1rem;
+        border-radius: 0.6rem;
+        border: none;
+        background: #3c5976;
+        color: #fff;
+        font-size: 1rem;
+        cursor: pointer;
+      }
+
+      /* Control surface */
+      .back {
+        color: #9fb3c8;
+        text-decoration: none;
+        font-size: 0.9rem;
+      }
+      .now {
+        border: 1px solid #2c3340;
+        border-radius: 0.9rem;
+        padding: 1rem 1.1rem;
+        background: #1b1e25;
+      }
+      .now-story {
+        margin: 0 0 0.25rem;
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        opacity: 0.55;
+      }
+      .now-scene {
+        margin: 0;
+        font-size: 1.45rem;
+        line-height: 1.2;
+      }
+      .now-page {
+        margin: 0.4rem 0 0;
+        font-size: 0.85rem;
+        opacity: 0.6;
+      }
+      .links-label {
+        margin: 0 0 0.6rem;
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        opacity: 0.55;
+      }
+      .links-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.6rem;
+      }
+      .link-button {
+        width: 100%;
+        text-align: left;
+        padding: 1rem 1.1rem;
+        border-radius: 0.8rem;
+        border: 1px solid #3c5976;
+        background: #2c3e50;
+        color: #ecf0f1;
+        font-family: inherit;
+        font-size: 1.1rem;
+        cursor: pointer;
+        transition: background 0.12s ease;
+      }
+      .link-button:active {
+        background: #3c5976;
+      }
+      .empty {
+        opacity: 0.55;
+        font-style: italic;
+      }
+    </style>
+  </body>
+</html>

--- a/src/pages/remote/index.astro
+++ b/src/pages/remote/index.astro
@@ -51,6 +51,17 @@
       <section class="control" data-control hidden>
         <a class="back" href="/remote">← Sessions</a>
 
+        <figure class="headset" data-headset hidden>
+          <div class="headset-pano">
+            <img class="headset-img" data-headset-img alt="" />
+            <p class="headset-noimg" data-headset-noimg hidden>no photosphere</p>
+          </div>
+          <figcaption class="headset-fiction">
+            <strong class="headset-heading" data-headset-heading></strong>
+            <span class="headset-body" data-headset-body></span>
+          </figcaption>
+        </figure>
+
         <section class="now" data-now hidden>
           <p class="now-story" data-story></p>
           <h2 class="now-scene" data-scene></h2>
@@ -63,6 +74,12 @@
         </section>
 
         <p class="empty" data-empty hidden>No exits from this page.</p>
+
+        <div class="control-actions">
+          <button type="button" class="restart-btn" data-restart>
+            ⟲ Back to start
+          </button>
+        </div>
       </section>
     </main>
 
@@ -81,9 +98,15 @@
         story: document.querySelector("[data-story]"),
         scene: document.querySelector("[data-scene]"),
         context: document.querySelector("[data-context]"),
+        headset: document.querySelector("[data-headset]"),
+        headsetImg: document.querySelector("[data-headset-img]"),
+        headsetNoimg: document.querySelector("[data-headset-noimg]"),
+        headsetHeading: document.querySelector("[data-headset-heading]"),
+        headsetBody: document.querySelector("[data-headset-body]"),
         links: document.querySelector("[data-links]"),
         linksList: document.querySelector("[data-links-list]"),
         empty: document.querySelector("[data-empty]"),
+        restart: document.querySelector("[data-restart]"),
       };
 
       const room = new URLSearchParams(location.search).get("room");
@@ -245,6 +268,12 @@
           socket.addEventListener("error", () => socket.close());
         };
 
+        el.restart.addEventListener("click", () => {
+          if (socket && socket.readyState === WebSocket.OPEN) {
+            socket.send(JSON.stringify({ type: "restart" }));
+          }
+        });
+
         open();
       }
 
@@ -266,6 +295,21 @@
           parts.push(`Page ${state.pageNumber + 1}`);
         }
         el.context.textContent = parts.join(" · ");
+
+        // Headset window: the scene photosphere with the page fiction over it —
+        // a 2D peek at roughly what's on the headset/projection screen.
+        el.headset.hidden = false;
+        if (state.image) {
+          el.headsetImg.src = state.image;
+          el.headsetImg.hidden = false;
+          el.headsetNoimg.hidden = true;
+        } else {
+          el.headsetImg.removeAttribute("src");
+          el.headsetImg.hidden = true;
+          el.headsetNoimg.hidden = false;
+        }
+        el.headsetHeading.textContent = heading;
+        el.headsetBody.textContent = state.body || "";
 
         el.linksList.replaceChildren();
         const links = Array.isArray(state.links) ? state.links : [];
@@ -423,6 +467,58 @@
         text-decoration: none;
         font-size: 0.9rem;
       }
+      .headset {
+        margin: 0;
+        border: 1px solid #2c3340;
+        border-radius: 0.9rem;
+        overflow: hidden;
+        background: #0e1014;
+      }
+      /* `.headset-img`/`.headset-noimg` set `display`, which would override the
+         `hidden` attribute; this scoped rule lets `hidden` win again. */
+      .headset [hidden] {
+        display: none;
+      }
+      .headset-pano {
+        position: relative;
+        height: 190px;
+        background: #0e1014;
+      }
+      .headset-img {
+        width: 100%;
+        height: 190px;
+        object-fit: cover;
+        object-position: center;
+        display: block;
+      }
+      .headset-noimg {
+        position: absolute;
+        inset: 0;
+        margin: 0;
+        display: grid;
+        place-items: center;
+        color: #5b6472;
+        font-style: italic;
+        font-size: 0.85rem;
+      }
+      .headset-fiction {
+        padding: 0.7rem 0.9rem;
+        background: rgba(20, 23, 28, 0.92);
+        display: grid;
+        gap: 0.3rem;
+      }
+      .headset-heading {
+        font-size: 1rem;
+        color: #ecf0f1;
+      }
+      .headset-body {
+        font-size: 0.85rem;
+        line-height: 1.35;
+        color: #b9c2cc;
+        white-space: pre-wrap;
+        max-height: 6.5em;
+        overflow-y: auto;
+      }
       .now {
         border: 1px solid #2c3340;
         border-radius: 0.9rem;
@@ -477,6 +573,25 @@
       .empty {
         opacity: 0.55;
         font-style: italic;
+      }
+      .control-actions {
+        margin-top: 0.25rem;
+      }
+      .restart-btn {
+        width: 100%;
+        padding: 0.7rem 1rem;
+        border-radius: 0.8rem;
+        border: 1px solid #3c4250;
+        background: transparent;
+        color: #9fb3c8;
+        font-family: inherit;
+        font-size: 0.95rem;
+        cursor: pointer;
+        transition: background 0.12s ease, color 0.12s ease;
+      }
+      .restart-btn:active {
+        background: #1f232b;
+        color: #ecf0f1;
       }
     </style>
   </body>

--- a/src/pages/story/[storyId]/index.astro
+++ b/src/pages/story/[storyId]/index.astro
@@ -213,6 +213,11 @@ const serializedContext = JSON.stringify(contextData)
   )}
 </body>
 
+<script>
+  import { startHostController } from "@components/story/remote/hostController";
+  startHostController();
+</script>
+
 <script is:inline>
   const toggle = document.querySelector(".interpretive-toggle");
   const drawer = document.querySelector(".interpretive-drawer");

--- a/src/server/createApiServer.ts
+++ b/src/server/createApiServer.ts
@@ -3,6 +3,7 @@ import type { Server } from "node:http";
 import express, { type RequestHandler } from "express";
 
 import type { ServerConfig } from "../environment/config.js";
+import attachRelay from "./relay/attachRelay.js";
 
 type StartServerResult = {
   server: Server;
@@ -32,6 +33,7 @@ function createApiServer(
 
   const startServer = async () => {
     const server = app.listen(config.port);
+    attachRelay(server);
     return { server, config };
   };
 

--- a/src/server/createServer.ts
+++ b/src/server/createServer.ts
@@ -4,6 +4,7 @@ import express, { type RequestHandler } from "express";
 
 import type { ServerConfig } from "../environment/config.js";
 import attachAstroMiddleware from "./attachAstroMiddleware.js";
+import attachRelay from "./relay/attachRelay.js";
 
 type StartServerResult = {
   server: Server;
@@ -37,6 +38,7 @@ function createServer(
 
   const startServer = async () => {
     const server = app.listen(config.port);
+    attachRelay(server);
     return { server, config };
   };
 

--- a/src/server/relay/attachRelay.ts
+++ b/src/server/relay/attachRelay.ts
@@ -1,0 +1,145 @@
+import type { Server } from "node:http";
+
+import { WebSocket, WebSocketServer } from "ws";
+
+import { sessionRegistry } from "./sessionRegistry.js";
+
+/**
+ * The path that remote-control clients (story "host" view and phone "remote"
+ * view) connect to. Anything else is left for other upgrade handlers.
+ */
+const RELAY_PATH = "/ws/relay";
+
+/**
+ * How often to ping clients to detect dead connections. A host that vanishes
+ * uncleanly (closed laptop, network drop, dyno kill) never sends a close frame,
+ * so without this its session would linger in the lobby as a zombie.
+ */
+const HEARTBEAT_MS = Number(process.env.RELAY_HEARTBEAT_MS ?? 30000);
+
+type Rooms = Map<string, Set<WebSocket>>;
+
+/** Tracks which sockets answered the last heartbeat ping. */
+const alive = new WeakMap<WebSocket, boolean>();
+
+/**
+ * A minimal in-memory relay for the remote-control feature.
+ *
+ * Clients connect with `?room=<code>` and every JSON message they send is
+ * forwarded verbatim to the other members of the same room. The server is
+ * deliberately dumb: it knows nothing about the message protocol — the story
+ * page and the phone page agree on that between themselves.
+ *
+ * State lives only in this process's memory, so it assumes a single dyno. If we
+ * ever scale horizontally this needs a shared pub/sub (e.g. Redis) instead.
+ */
+export default function attachRelay(server: Server): void {
+  const wss = new WebSocketServer({ noServer: true });
+  const rooms: Rooms = new Map();
+
+  const heartbeat = setInterval(() => {
+    const dead: WebSocket[] = [];
+    for (const peers of rooms.values()) {
+      for (const ws of peers) {
+        if (alive.get(ws) === false) {
+          dead.push(ws);
+          continue;
+        }
+        alive.set(ws, false);
+        try {
+          ws.ping();
+        } catch {
+          dead.push(ws);
+        }
+      }
+    }
+    // Terminate after iterating so we don't mutate the sets mid-loop; each
+    // terminate triggers a `close` that cleans up the room and registry.
+    for (const ws of dead) {
+      ws.terminate();
+    }
+  }, HEARTBEAT_MS);
+
+  server.on("close", () => clearInterval(heartbeat));
+
+  server.on("upgrade", (req, socket, head) => {
+    let pathname: string;
+    let room: string | null;
+    let role: string;
+
+    try {
+      const url = new URL(req.url ?? "", "http://localhost");
+      pathname = url.pathname;
+      room = url.searchParams.get("room");
+      role = url.searchParams.get("role") ?? "remote";
+    } catch {
+      socket.destroy();
+      return;
+    }
+
+    if (pathname !== RELAY_PATH) {
+      return;
+    }
+
+    if (!room) {
+      socket.destroy();
+      return;
+    }
+
+    const roomCode = room;
+    const roomRole = role;
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      joinRoom(rooms, roomCode, roomRole, ws);
+    });
+  });
+}
+
+function joinRoom(
+  rooms: Rooms,
+  room: string,
+  role: string,
+  ws: WebSocket,
+): void {
+  let peers = rooms.get(room);
+  if (!peers) {
+    peers = new Set();
+    rooms.set(room, peers);
+  }
+  peers.add(ws);
+  sessionRegistry.join(room, role, ws);
+
+  alive.set(ws, true);
+  ws.on("pong", () => alive.set(ws, true));
+
+  ws.on("message", (data, isBinary) => {
+    // Keep the lobby's snapshot of the room fresh, but stay a blind forwarder
+    // otherwise — clients own the message protocol.
+    if (!isBinary) {
+      try {
+        const message = JSON.parse(data.toString());
+        if (message?.type === "state") {
+          sessionRegistry.recordState(room, message);
+        }
+      } catch {
+        // not JSON we care about; forward it anyway
+      }
+    }
+
+    for (const peer of peers) {
+      if (peer !== ws && peer.readyState === WebSocket.OPEN) {
+        peer.send(data, { binary: isBinary });
+      }
+    }
+  });
+
+  const leave = () => {
+    peers.delete(ws);
+    if (peers.size === 0) {
+      rooms.delete(room);
+    }
+    sessionRegistry.leave(room, ws);
+  };
+
+  ws.on("close", leave);
+  ws.on("error", leave);
+}

--- a/src/server/relay/routeSessions.ts
+++ b/src/server/relay/routeSessions.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+
+import isStewardUser from "../../authentication/isStewardUser.js";
+import { sessionRegistry } from "./sessionRegistry.js";
+
+/**
+ * Lists the currently-live remote-control sessions for the lobby page.
+ * Mounted under `/api`, so the path is `/api/sessions`.
+ *
+ * Discovery is steward-only: browsing *all* live sessions is a privileged view.
+ * Joining a single session you were handed a code/QR for is capability-based
+ * and handled by the relay, not here. (Authenticating the relay socket itself
+ * is a separate, larger auth task.)
+ */
+export default function routeSessions(): Router {
+  return Router().get("/sessions", (req, res) => {
+    if (!isStewardUser(req.user, req.headers.cookie)) {
+      res.status(403).json({ error: "Stewards only" });
+      return;
+    }
+    res.json({ sessions: sessionRegistry.list() });
+  });
+}

--- a/src/server/relay/sessionRegistry.ts
+++ b/src/server/relay/sessionRegistry.ts
@@ -1,0 +1,102 @@
+import type { WebSocket } from "ws";
+
+/**
+ * What the lobby ("active sessions" page) shows for each live session.
+ */
+export type SessionSummary = {
+  code: string;
+  storyTitle: string;
+  heading: string;
+  sceneTitle: string;
+  clients: number;
+};
+
+type StateSnapshot = {
+  storyTitle?: string;
+  heading?: string;
+  sceneTitle?: string;
+};
+
+type Session = {
+  peers: Set<WebSocket>;
+  hosts: Set<WebSocket>;
+  lastState: StateSnapshot | null;
+  createdAt: number;
+};
+
+/**
+ * Tracks which remote-control sessions are currently live so the lobby can list
+ * them. This is the one piece of state the relay keeps beyond blind forwarding:
+ * it remembers who is connected to each room and the last state a host
+ * broadcast, so a co-pilot can browse and join sessions.
+ *
+ * Process-local (single dyno), like the relay itself.
+ */
+function createSessionRegistry() {
+  const sessions = new Map<string, Session>();
+
+  const ensure = (code: string): Session => {
+    let session = sessions.get(code);
+    if (!session) {
+      session = {
+        peers: new Set(),
+        hosts: new Set(),
+        lastState: null,
+        createdAt: Date.now(),
+      };
+      sessions.set(code, session);
+    }
+    return session;
+  };
+
+  return {
+    join(code: string, role: string, ws: WebSocket): void {
+      const session = ensure(code);
+      session.peers.add(ws);
+      if (role === "host") {
+        session.hosts.add(ws);
+      }
+    },
+
+    recordState(code: string, state: StateSnapshot): void {
+      const session = sessions.get(code);
+      if (!session) {
+        return;
+      }
+      session.lastState = {
+        storyTitle: state.storyTitle,
+        heading: state.heading,
+        sceneTitle: state.sceneTitle,
+      };
+    },
+
+    leave(code: string, ws: WebSocket): void {
+      const session = sessions.get(code);
+      if (!session) {
+        return;
+      }
+      session.peers.delete(ws);
+      session.hosts.delete(ws);
+      if (session.peers.size === 0) {
+        sessions.delete(code);
+      }
+    },
+
+    /** Only sessions that have a live experience (a host) are listed. */
+    list(): SessionSummary[] {
+      return [...sessions.entries()]
+        .filter(([, session]) => session.hosts.size > 0)
+        .sort((a, b) => a[1].createdAt - b[1].createdAt)
+        .map(([code, session]) => ({
+          code,
+          storyTitle: session.lastState?.storyTitle ?? "",
+          heading: session.lastState?.heading ?? "",
+          sceneTitle: session.lastState?.sceneTitle ?? "",
+          clients: session.peers.size,
+        }));
+    },
+  };
+}
+
+export const sessionRegistry = createSessionRegistry();
+export type SessionRegistry = ReturnType<typeof createSessionRegistry>;


### PR DESCRIPTION
Phone/laptop **remote control** for a live story session — drive and monitor the
story viewer (headset second-monitor, SimLab projection) from a second device.

### What's here
- **WebSocket relay** (`/ws/relay`): in-memory, room-keyed, with a ping/pong
  heartbeat that reaps dead sessions. Attached to both the prod and dev servers.
- **Lobby** (`/remote`): a grid of live sessions — click-through tiles plus a QR
  to scan from a laptop screen. Discovery is **steward-gated** (`/api/sessions`);
  joining a single session by code/QR stays capability-based.
- **Control surface** (`/remote?room=CODE`): the current scene/page, the page's
  exits as buttons (drive), a **headset window** (the scene photosphere + fiction
  — a 2D peek at what's on screen), and a **"⟲ Back to start"** control.
- **Host side**: the story page arms only when opened with `?room=` (auto-generates
  a short code, shows a badge); it broadcasts state and applies `navigate`/`restart`
  by re-emitting the same events a click would. Host socket auto-reconnects.

Normal viewing is unaffected — the host does nothing without a `?room=`.

### Status
Opened as a **draft**: this is an early but demo-ready feature. Known follow-ups
before it's merge-ready: authenticating the relay socket itself (today a room
code is a bearer capability), scoping the lobby beyond steward, and optional
camera-orientation sync so the headset window tracks where the user is looking.

### Testing
- Server typechecks.
- Verified end-to-end with Playwright: lobby tiles + QR, click-through, drive,
  multi-session isolation, host auto-reconnect, heartbeat reap, steward gating,
  headset window updates, and back-to-start from a deep page.
