### PR TITLE
Fix scene save/delete crashing (SceneFiction expected `story`, got `storyId`)

### DIFF
--- a/src/components/story/edit/scene/fiction/SceneFiction.tsx
+++ b/src/components/story/edit/scene/fiction/SceneFiction.tsx
@@ -37,13 +37,13 @@ import styles from "./SceneFiction.module.css";
 import type { LinkTarget } from "@domain/story/publish/types";
 
 type SceneFictionProps = {
-  story: PersistentStory;
+  storyId: PersistentStory["id"];
   scene: PersistentScene;
   onSceneChanged: OnSceneChanged;
 };
 
 const SceneFiction: FC<SceneFictionProps> = ({
-  story,
+  storyId,
   scene,
   onSceneChanged,
 }) => {
@@ -59,7 +59,7 @@ const SceneFiction: FC<SceneFictionProps> = ({
 
   const saveTheSceneContent = useMutation<string, Error, string>({
     mutationFn: (content) =>
-      saveSceneContent({ storyId: story.id, sceneId: scene.id, content }).then(
+      saveSceneContent({ storyId, sceneId: scene.id, content }).then(
         (result) => {
           switch (result.kind) {
             case "sceneContentSaved": {
@@ -98,7 +98,7 @@ const SceneFiction: FC<SceneFictionProps> = ({
 
   const deleteTheScene = useMutation<unknown, Error, PersistentScene["id"]>({
     mutationFn: (sceneId) =>
-      deleteScene({ storyId: story.id, sceneId }).then((result) => {
+      deleteScene({ storyId, sceneId }).then((result) => {
         switch (result.kind) {
           case "sceneDeleted":
             return;


### PR DESCRIPTION
## Saving (and deleting) a scene is broken on `main`

In the story editor, clicking the scene **save** icon throws and shows a generic
"Oops, something went wrong" — with **no network request and no console error**,
which makes it hard to diagnose. Same for delete.

### Cause
`SceneFiction`'s props declare `story: PersistentStory` and read `story.id`, but
`Scene` renders `<SceneFiction storyId={…}>`. So `story` is `undefined`, and
`story.id` throws **synchronously inside the React-Query mutation** — caught by
`onError` (hence the modal, and no fetch).

This was introduced by the `story → storyId` refactor in **"Integrate PRs 268
and 270"**: that commit renamed `Scene` to use `storyId` and updated the
`<SceneFiction>` call site (`story={story}` → `storyId={storyId}`), but didn't
update `SceneFiction`'s own prop. `astro check` flags it
(`Scene.tsx ts(2322): … not assignable to 'SceneFictionProps'`); it compiles and
only crashes at runtime on save.

### Fix
`SceneFiction` only needs the id, so accept `storyId` directly (matches what
`Scene` already passes). One line each for the type, the destructure, and the two
`story.id` reads. Clears the type error too.

Verified: the save endpoint works (`PUT …/content` → 204); the crash was purely
the undefined-`story` deref before the fetch.

### Note
Two sibling `exactOptionalPropertyTypes` errors from the same refactor remain
(`EditStory.tsx:316`, `Scene.tsx:139`, both on `linkInfo`) — lower risk (not a
null deref), can be a follow-up.
