### PR TITLE
Add a subtle save-state halo to the scene editor

### DIFF
--- a/src/components/story/edit/scene/fiction/SceneFiction.module.css
+++ b/src/components/story/edit/scene/fiction/SceneFiction.module.css
@@ -10,3 +10,30 @@
   border-radius: var(--border-radius-medium);
   font-size: 1.5rem;
 }
+
+/* Save-state halos behind the save icon: orange-red glow = unsaved edits,
+   green glow = saved. The dirty halo pulses to draw the eye. */
+.saveDirty,
+.saveSaved {
+  position: relative;
+  z-index: 2;
+  transition: box-shadow 0.3s ease;
+}
+
+.saveDirty {
+  animation: saveDirtyPulse 10s ease-in-out infinite;
+}
+
+.saveSaved {
+  box-shadow: 0 0 3px 1px rgba(46, 204, 113, 0.7);
+}
+
+@keyframes saveDirtyPulse {
+  0%,
+  100% {
+    box-shadow: 0 0 2px 0 rgba(255, 100, 30, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 4px 1px rgba(255, 100, 30, 0.8);
+  }
+}

--- a/src/components/story/edit/scene/fiction/SceneFiction.tsx
+++ b/src/components/story/edit/scene/fiction/SceneFiction.tsx
@@ -57,6 +57,19 @@ const SceneFiction: FC<SceneFictionProps> = ({
 
   const [editorState] = useState(toSlateModel(scene));
 
+  // Visual save state: clean (just loaded) → dirty (edited, orange halo) →
+  // saved (green halo). Drops back to dirty on the next content edit.
+  const [saveState, setSaveState] = useState<"clean" | "dirty" | "saved">(
+    "clean",
+  );
+
+  const onContentChange = () => {
+    // Slate fires onChange for cursor moves too; only real edits make it dirty.
+    if (editor.operations.some((op) => op.type !== "set_selection")) {
+      setSaveState("dirty");
+    }
+  };
+
   const saveTheSceneContent = useMutation<string, Error, string>({
     mutationFn: (content) =>
       saveSceneContent({ storyId, sceneId: scene.id, content }).then(
@@ -84,6 +97,7 @@ const SceneFiction: FC<SceneFictionProps> = ({
       ),
     onError: feedback.notify.error,
     onSuccess: (content) => {
+      setSaveState("saved");
       onSceneChanged({
         kind: "contentChanged",
         id: scene.id,
@@ -219,7 +233,11 @@ const SceneFiction: FC<SceneFictionProps> = ({
 
   return (
     <div className={styles.sceneFiction}>
-      <Slate editor={editor} initialValue={editorState}>
+      <Slate
+        editor={editor}
+        initialValue={editorState}
+        onChange={onContentChange}
+      >
         <Toolbar>
           <button
             type="button"
@@ -234,6 +252,13 @@ const SceneFiction: FC<SceneFictionProps> = ({
           </button>
           <button
             type="button"
+            className={
+              saveState === "dirty"
+                ? styles.saveDirty
+                : saveState === "saved"
+                  ? styles.saveSaved
+                  : undefined
+            }
             onClick={onSave}
             disabled={saveTheSceneContent.isPending}
           >


### PR DESCRIPTION
## Save-state feedback in the scene editor

The story editor currently gives no indication of whether scene content has
**unsaved changes** or was **saved**. This adds a subtle halo behind the save
icon:

- **Unsaved edits** → a faint orange glow that breathes very slowly (10s) — just
  enough to notice in the periphery without pulling focus.
- **Saved** → a quiet green glow, which clears back to orange on the next edit.

State is driven by Slate's `onChange` (ignoring cursor-only moves) and the save
mutation's `onSuccess` — ~50 lines, no new dependencies.

### Status — opening for opinions, not to merge yet
This is a **taste call**, so I'd like feedback before merging — happy to tune the
colours/intensity/timing, or drop it entirely if folks prefer the editor stay
quiet. (Builds on the save fix in #307.)
